### PR TITLE
User feed fixes

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -140,7 +140,7 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Post"/>
                                 <connections>
-                                    <segue destination="jJ4-Fu-ear" kind="presentation" id="FhU-5a-82J"/>
+                                    <segue destination="jJ4-Fu-ear" kind="presentation" identifier="composeSegue" id="FhU-5a-82J"/>
                                 </connections>
                             </button>
                         </barButtonItem>

--- a/CapstoneProject/Models/Post.m
+++ b/CapstoneProject/Models/Post.m
@@ -9,6 +9,7 @@
 
 @implementation Post
 
+
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary {
     self = [super init];
 

--- a/CapstoneProject/View Controllers/ComposeViewController.h
+++ b/CapstoneProject/View Controllers/ComposeViewController.h
@@ -6,10 +6,19 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "Post.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol ComposeViewControllerDelegate
+
+-(void)didPost:(Post *)post;
+
+@end
+
 @interface ComposeViewController : UIViewController
+
+@property (nonatomic, weak) id<ComposeViewControllerDelegate> delegate;
 
 @end
 

--- a/CapstoneProject/View Controllers/ComposeViewController.m
+++ b/CapstoneProject/View Controllers/ComposeViewController.m
@@ -37,7 +37,6 @@
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
-            NSLog(@"%@", result);
             Post *post = [self createPostObject:result[@"id"]];
             [self.delegate didPost:post];
         } else {
@@ -66,6 +65,7 @@
         }
     }];
     
+    NSLog(@"New post is %@", newPost);
     return newPost;
 }
 

--- a/CapstoneProject/View Controllers/ComposeViewController.m
+++ b/CapstoneProject/View Controllers/ComposeViewController.m
@@ -7,6 +7,7 @@
 
 #import "ComposeViewController.h"
 #import "FBSDKCoreKit/FBSDKCoreKit.h"
+#import "Post.h"
 
 @interface ComposeViewController ()
 @property (weak, nonatomic) IBOutlet UITextView *postText;
@@ -25,6 +26,10 @@
 }
 
 - (IBAction)didTapPost:(id)sender {
+    [self composePost];
+}
+
+-(void)composePost {
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
         initWithGraphPath:@"/425184976239857/feed"
                parameters:@{ @"message": self.postText.text,}
@@ -33,7 +38,8 @@
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
             NSLog(@"%@", result);
-
+            Post *post = [self createPostObject:result[@"id"]];
+            [self.delegate didPost:post];
         } else {
             NSLog(@"Error posting to feed: %@", error.localizedDescription);
         }
@@ -42,6 +48,26 @@
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
+- (Post *)createPostObject: (NSString* _Nullable)post_id {
+    
+    __block Post *newPost = nil;
+    
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+        initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
+        parameters:@{ @"fields": @"from, created_time, message"}
+        HTTPMethod:@"GET"];
+    
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        if (!error) {
+            NSLog(@"%@", result);
+            newPost = [[Post alloc] initWithDictionary:result];
+        } else {
+            NSLog(@"Error posting to feed: %@", error.localizedDescription);
+        }
+    }];
+    
+    return newPost;
+}
 
 
 /*

--- a/CapstoneProject/View Controllers/ComposeViewController.m
+++ b/CapstoneProject/View Controllers/ComposeViewController.m
@@ -31,9 +31,9 @@
 
 -(void)composePost {
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-        initWithGraphPath:@"/425184976239857/feed"
-               parameters:@{ @"message": self.postText.text,}
-               HTTPMethod:@"POST"];
+                                  initWithGraphPath:@"/425184976239857/feed"
+                                  parameters:@{ @"message": self.postText.text,}
+                                  HTTPMethod:@"POST"];
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
@@ -58,9 +58,9 @@
     __block Post *newPost = nil;
     
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-        initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
-        parameters:@{ @"fields": @"from, created_time, message"}
-        HTTPMethod:@"GET"];
+                                  initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
+                                  parameters:@{ @"fields": @"from, created_time, message"}
+                                  HTTPMethod:@"GET"];
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
@@ -77,9 +77,9 @@
 
 -(void)getPostWithID:(NSString *)post_id completion:(void (^)(Post *, NSError *))completion {
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-        initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
-        parameters:@{ @"fields": @"from, created_time, message"}
-        HTTPMethod:@"GET"];
+                                  initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
+                                  parameters:@{ @"fields": @"from, created_time, message"}
+                                  HTTPMethod:@"GET"];
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
@@ -93,15 +93,5 @@
     }];
 }
 
-
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
 
 @end

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.h
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface QuestionFeedViewController : UIViewController
+@interface QuestionFeedViewController : UIViewController <UITableViewDataSource>
 
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *logoutButton;
 

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -94,7 +94,8 @@
 }
 
 - (void)didPost:(nonnull Post *)post {
-    [self.postArray insertObject:post atIndex:0];
+    //[self.postArray insertObject:post atIndex:0];
+    [self fetchPosts];
     [self.tableView reloadData];
 }
 

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -70,17 +70,6 @@
     NSLog(@"%@", [FBSDKAccessToken currentAccessToken]);
 }
 
-
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
-
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
     PostCell *cell = [tableView dequeueReusableCellWithIdentifier:@"PostCell"];
         
@@ -99,5 +88,16 @@
     [self.tableView reloadData];
 }
 
+
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    if([segue.identifier isEqualToString:@"composeSegue"]) {
+        UINavigationController *navigationController = [segue destinationViewController];
+        ComposeViewController *composeController = (ComposeViewController*)navigationController.topViewController;
+        composeController.delegate = self;
+    }
+}
 
 @end

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -31,9 +31,9 @@
     [self fetchPosts];
     
     // Initialize a UIRefreshControl
-        self.refreshControl = [[UIRefreshControl alloc] init];
-        [self.refreshControl addTarget:self action:@selector(fetchPosts) forControlEvents:UIControlEventValueChanged];
-        [self.tableView insertSubview:self.refreshControl atIndex:0];
+    self.refreshControl = [[UIRefreshControl alloc] init];
+    [self.refreshControl addTarget:self action:@selector(fetchPosts) forControlEvents:UIControlEventValueChanged];
+    [self.tableView insertSubview:self.refreshControl atIndex:0];
 }
 
 
@@ -42,7 +42,7 @@
     [logoutManager logOut];
     
     NSLog(@"%@", [FBSDKAccessToken currentAccessToken]);
-
+    
     
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
     FBLoginViewController *loginViewController = [storyboard instantiateViewControllerWithIdentifier:@"FBLoginViewController"];
@@ -51,9 +51,9 @@
 
 -(void)fetchPosts {
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-        initWithGraphPath:@"/425184976239857/feed"
-        parameters:@{ @"fields": @"from, created_time, message"}
-        HTTPMethod:@"GET"];
+                                  initWithGraphPath:@"/425184976239857/feed"
+                                  parameters:@{ @"fields": @"from, created_time, message"}
+                                  HTTPMethod:@"GET"];
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
@@ -72,9 +72,9 @@
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
     PostCell *cell = [tableView dequeueReusableCellWithIdentifier:@"PostCell"];
-        
+    
     [cell setPost:self.postArray[indexPath.row]];
-        
+    
     return cell;
 }
 
@@ -83,7 +83,6 @@
 }
 
 - (void)didPost:(nonnull Post *)post {
-    //[self.postArray insertObject:post atIndex:0];
     [self fetchPosts];
     [self.tableView reloadData];
 }
@@ -91,7 +90,6 @@
 
 #pragma mark - Navigation
 
-// In a storyboard-based application, you will often want to do a little preparation before navigation
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
     if([segue.identifier isEqualToString:@"composeSegue"]) {
         UINavigationController *navigationController = [segue destinationViewController];

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -13,7 +13,7 @@
 #import "Post.h"
 #import "ComposeViewController.h"
 
-@interface QuestionFeedViewController () <UITableViewDelegate, UITableViewDataSource>
+@interface QuestionFeedViewController () <ComposeViewControllerDelegate, UITableViewDelegate, UITableViewDataSource>
 
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
@@ -84,9 +84,9 @@
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
     PostCell *cell = [tableView dequeueReusableCellWithIdentifier:@"PostCell"];
         
-        [cell setPost:self.postArray[indexPath.row]];
+    [cell setPost:self.postArray[indexPath.row]];
         
-        return cell;
+    return cell;
 }
 
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {

--- a/CapstoneProject/Views/PostCell.m
+++ b/CapstoneProject/Views/PostCell.m
@@ -18,8 +18,6 @@
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
 }
 
 -(void)setPost:(Post *)post {


### PR DESCRIPTION
### Context
This PR fixes the issues with displaying the user feed that we saw in #7 . When the user composes the new post and is led back to the feed, the new post pops up at the top of the feed unlike the last PR, where we needed to physically refresh the page.

https://user-images.githubusercontent.com/107252243/179113615-7c9a7c94-8c0e-46fa-a029-5ee6df6a3d73.mov

### Test plan
1. Click the login button to login with Facebook credentials.
2. Click the “Post” button at the top right of the feed.
3. Type a message into the text field and click the “Post” button to compose.
4. The user should be lead back to the home feed and see the post with the message in Step 3 pop up.

### MVP features implemented
This PR fixes the “Compose a post and update the corresponding course feed” feature.