### PR TITLE
Date fixes

### DIFF
--- a/CapstoneProject/Models/Post.m
+++ b/CapstoneProject/Models/Post.m
@@ -11,7 +11,7 @@
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary {
     self = [super init];
-
+    
     if (self) {
         NSLog(@"%@", dictionary);
         self.user_id = dictionary[@"from"][@"id"];
@@ -25,11 +25,6 @@
         
         NSDate *date = [formatter dateFromString:createdAtOriginalString];     // Convert String to Date
         self.post_date = date;
-        
-        NSLog(@"createdAt = %@", createdAtOriginalString);
-        NSLog(@"class %@", [createdAtOriginalString class]);
-        NSLog(@"date = %@", date);
-        NSLog(@"post_date = %@", self.post_date);
         
         formatter.dateStyle = NSDateFormatterShortStyle;     // Configure output format
         formatter.timeStyle = NSDateFormatterNoStyle;

--- a/CapstoneProject/Models/Post.m
+++ b/CapstoneProject/Models/Post.m
@@ -21,10 +21,15 @@
         
         NSString *createdAtOriginalString = dictionary[@"created_time"];
         NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-        formatter.dateFormat = @"E MMM d HH:mm:ss Z y";     // Configure the input format to parse the date string
+        formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZ";     // Configure the input format to parse the date string
         
         NSDate *date = [formatter dateFromString:createdAtOriginalString];     // Convert String to Date
         self.post_date = date;
+        
+        NSLog(@"createdAt = %@", createdAtOriginalString);
+        NSLog(@"class %@", [createdAtOriginalString class]);
+        NSLog(@"date = %@", date);
+        NSLog(@"post_date = %@", self.post_date);
         
         formatter.dateStyle = NSDateFormatterShortStyle;     // Configure output format
         formatter.timeStyle = NSDateFormatterNoStyle;


### PR DESCRIPTION
### Context
This small change adds on to the feed viewing feature in #7. Before, the date and timestamp would not show up on each post. Fixing the date formatter, which was taking in the wrong input date format, solved this issue.

### Test plan
1. Click the login button to login with Facebook credentials.
2. The user should see a feed with correct dates and timestamps for each post.
3. To further verify that this functionality works, after merging #8 , the user can follow the test plan in #8 to make sure the a newly composed post will also show the correct dates/times.


https://user-images.githubusercontent.com/107252243/179116340-3bee0da5-69b6-4bb1-af9f-edc206f211bd.mov


### MVP features implemented
This PR fixes the “Upon login, display feed for course that was viewed last during last login session” and “Compose a post and update the corresponding course feed” features.