### PR TITLE
Post details view

### DIFF
--- a/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject.xcodeproj/project.pbxproj
@@ -9,10 +9,12 @@
 /* Begin PBXBuildFile section */
 		0DD0EF32807DCAD0A1620E3D /* Pods_CapstoneProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C76E1444D957C3582942E6D2 /* Pods_CapstoneProject.framework */; };
 		76A39FE0FECDB0E40A1CB644 /* Pods_CapstoneProjectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 646B9531342764967FC8DCA9 /* Pods_CapstoneProjectTests.framework */; };
+		BE05CF302880C97D00899BE9 /* TabBarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05CF2F2880C97D00899BE9 /* TabBarViewController.m */; };
 		BE05CF3328820E1500899BE9 /* SelectCourseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05CF3228820E1500899BE9 /* SelectCourseViewController.m */; };
 		BE05CF3628820F4400899BE9 /* CourseCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05CF3528820F4400899BE9 /* CourseCell.m */; };
-		BE05CF302880C97D00899BE9 /* TabBarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05CF2F2880C97D00899BE9 /* TabBarViewController.m */; };
 		BE1762E3287BDE0300B7DD03 /* ComposeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1762E2287BDE0300B7DD03 /* ComposeViewController.m */; };
+		BE53E1272888AD3000744F3A /* PostDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE53E1262888AD3000744F3A /* PostDetailsViewController.m */; };
+		BE53E12A2888AD6C00744F3A /* AnsweringViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE53E1292888AD6C00744F3A /* AnsweringViewController.m */; };
 		BE8277D7287C8DDD0059B509 /* PostCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8277D6287C8DDD0059B509 /* PostCell.m */; };
 		BE8277DB287C91230059B509 /* Post.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8277DA287C91230059B509 /* Post.m */; };
 		BEA4666B28781C1F00D57C23 /* FBLoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BEA4666A28781C1F00D57C23 /* FBLoginViewController.m */; };
@@ -56,14 +58,18 @@
 		646B9531342764967FC8DCA9 /* Pods_CapstoneProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CapstoneProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82FAADA8062714733CF4DD2B /* Pods-CapstoneProject-CapstoneProjectUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CapstoneProject-CapstoneProjectUITests.debug.xcconfig"; path = "Target Support Files/Pods-CapstoneProject-CapstoneProjectUITests/Pods-CapstoneProject-CapstoneProjectUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		853EA4DD722796AA0D889F4D /* Pods-CapstoneProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CapstoneProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-CapstoneProjectTests/Pods-CapstoneProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
+		BE05CF2E2880C97D00899BE9 /* TabBarViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TabBarViewController.h; sourceTree = "<group>"; };
+		BE05CF2F2880C97D00899BE9 /* TabBarViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TabBarViewController.m; sourceTree = "<group>"; };
 		BE05CF3128820E1500899BE9 /* SelectCourseViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SelectCourseViewController.h; sourceTree = "<group>"; };
 		BE05CF3228820E1500899BE9 /* SelectCourseViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SelectCourseViewController.m; sourceTree = "<group>"; };
 		BE05CF3428820F4400899BE9 /* CourseCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CourseCell.h; sourceTree = "<group>"; };
 		BE05CF3528820F4400899BE9 /* CourseCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CourseCell.m; sourceTree = "<group>"; };
-		BE05CF2E2880C97D00899BE9 /* TabBarViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TabBarViewController.h; sourceTree = "<group>"; };
-		BE05CF2F2880C97D00899BE9 /* TabBarViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TabBarViewController.m; sourceTree = "<group>"; };
 		BE1762E1287BDE0300B7DD03 /* ComposeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ComposeViewController.h; sourceTree = "<group>"; };
 		BE1762E2287BDE0300B7DD03 /* ComposeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ComposeViewController.m; sourceTree = "<group>"; };
+		BE53E1252888AD3000744F3A /* PostDetailsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostDetailsViewController.h; sourceTree = "<group>"; };
+		BE53E1262888AD3000744F3A /* PostDetailsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PostDetailsViewController.m; sourceTree = "<group>"; };
+		BE53E1282888AD6C00744F3A /* AnsweringViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AnsweringViewController.h; sourceTree = "<group>"; };
+		BE53E1292888AD6C00744F3A /* AnsweringViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AnsweringViewController.m; sourceTree = "<group>"; };
 		BE8277D5287C8DDD0059B509 /* PostCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostCell.h; sourceTree = "<group>"; };
 		BE8277D6287C8DDD0059B509 /* PostCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PostCell.m; sourceTree = "<group>"; };
 		BE8277D9287C91230059B509 /* Post.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Post.h; sourceTree = "<group>"; };
@@ -184,6 +190,10 @@
 				BE05CF2F2880C97D00899BE9 /* TabBarViewController.m */,
 				BEB921482884FC33004FA147 /* GameViewController.h */,
 				BEB921492884FC33004FA147 /* GameViewController.m */,
+				BE53E1252888AD3000744F3A /* PostDetailsViewController.h */,
+				BE53E1262888AD3000744F3A /* PostDetailsViewController.m */,
+				BE53E1282888AD6C00744F3A /* AnsweringViewController.h */,
+				BE53E1292888AD6C00744F3A /* AnsweringViewController.m */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -228,8 +238,6 @@
 				BEDF114E2874FA0A00B080A4 /* AppDelegate.m */,
 				BEDF11502874FA0A00B080A4 /* SceneDelegate.h */,
 				BEDF11512874FA0A00B080A4 /* SceneDelegate.m */,
-				BEDF11532874FA0A00B080A4 /* ViewController.h */,
-				BEDF11542874FA0A00B080A4 /* ViewController.m */,
 				BEB9214E28850834004FA147 /* SpriteKit Scenes */,
 				BE8277D8287C91040059B509 /* Models */,
 				BE8277D4287C8DAB0059B509 /* Views */,
@@ -500,9 +508,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE05CF302880C97D00899BE9 /* TabBarViewController.m in Sources */,
+				BE53E12A2888AD6C00744F3A /* AnsweringViewController.m in Sources */,
 				BEB9214A2884FC33004FA147 /* GameViewController.m in Sources */,
-				BEDF11552874FA0A00B080A4 /* ViewController.m in Sources */,
 				BEDF114F2874FA0A00B080A4 /* AppDelegate.m in Sources */,
+				BE53E1272888AD3000744F3A /* PostDetailsViewController.m in Sources */,
 				BEB921562885089D004FA147 /* ParticleScene.m in Sources */,
 				BEDF11602874FA0A00B080A4 /* main.m in Sources */,
 				BE8277D7287C8DDD0059B509 /* PostCell.m in Sources */,

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -105,7 +105,7 @@
                                             <outlet property="nameLabel" destination="bgV-G6-RZz" id="Fgo-Gg-Naa"/>
                                             <outlet property="postText" destination="aX1-Aq-cAU" id="yAM-Od-kj0"/>
                                             <outlet property="timestampLabel" destination="VbD-iK-BxT" id="eFF-Nv-lBj"/>
-                                            <segue destination="X95-fU-b2f" kind="show" id="jcq-FU-8fD"/>
+                                            <segue destination="X95-fU-b2f" kind="show" identifier="detailsSegue" id="jcq-FU-8fD"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -105,6 +105,7 @@
                                             <outlet property="nameLabel" destination="bgV-G6-RZz" id="Fgo-Gg-Naa"/>
                                             <outlet property="postText" destination="aX1-Aq-cAU" id="yAM-Od-kj0"/>
                                             <outlet property="timestampLabel" destination="VbD-iK-BxT" id="eFF-Nv-lBj"/>
+                                            <segue destination="X95-fU-b2f" kind="show" id="jcq-FU-8fD"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -153,6 +154,128 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9Vf-R5-9fS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1249" y="873"/>
+        </scene>
+        <!--Post Details View Controller-->
+        <scene sceneID="OtQ-xi-EnW">
+            <objects>
+                <viewController id="X95-fU-b2f" customClass="PostDetailsViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Quh-TJ-bpF">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
+                                <rect key="frame" x="20" y="104" width="374" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C7U-GX-NSk">
+                                <rect key="frame" x="20" y="255" width="374" height="106"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y5W-ns-RF6">
+                                <rect key="frame" x="108" y="164" width="223" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BEg-Qw-3QV">
+                                <rect key="frame" x="20" y="158" width="64" height="62"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="tintColor" red="0.47478711530000001" green="0.48709458709999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="07/20/22" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="87f-VR-vJw">
+                                <rect key="frame" x="108" y="193" width="68" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33p-eE-T9X">
+                                <rect key="frame" x="233" y="381" width="161" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Answer this Question"/>
+                                <connections>
+                                    <segue destination="z7o-os-hQ5" kind="presentation" id="Q7C-pp-3Tv"/>
+                                </connections>
+                            </button>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="cLz-zM-xIt">
+                                <rect key="frame" x="0.0" y="491" width="414" height="405"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="188" id="B4x-OK-N2B">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="188"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="B4x-OK-N2B" id="NHe-zp-JAe">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="188"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2Q-ad-h1I">
+                                <rect key="frame" x="20" y="435" width="82" height="27"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VwJ-Dz-ude">
+                                <rect key="frame" x="20" y="470" width="374" height="1"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemGray3Color"/>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="bRU-Qa-uYY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Czr-1w-inP"/>
+                    <connections>
+                        <outlet property="dateLabel" destination="87f-VR-vJw" id="Ic2-of-52j"/>
+                        <outlet property="descriptionLabel" destination="C7U-GX-NSk" id="gF8-52-Ub3"/>
+                        <outlet property="nameLabel" destination="y5W-ns-RF6" id="Qqg-sC-HpF"/>
+                        <outlet property="profileImage" destination="BEg-Qw-3QV" id="JY1-rU-1Rn"/>
+                        <outlet property="titleLabel" destination="6ZA-sR-0Ay" id="tHF-LY-0Sf"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="M70-2L-cLp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1249.2753623188407" y="1674.7767857142856"/>
+        </scene>
+        <!--Answering View Controller-->
+        <scene sceneID="kno-hb-7Ng">
+            <objects>
+                <viewController id="cRq-wp-yDg" customClass="AnsweringViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="k39-37-4nc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="2AA-nj-rcc"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="fdh-vX-rEK">
+                        <barButtonItem key="leftBarButtonItem" style="plain" id="Xod-G2-fc9">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="ii4-d9-cV3" userLabel="Cancel">
+                                <rect key="frame" x="20" y="12.5" width="92" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Cancel"/>
+                                <connections>
+                                    <action selector="didTapCancel:" destination="cRq-wp-yDg" eventType="touchUpInside" id="N89-5D-OGw"/>
+                                </connections>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lC7-lb-6Tt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="632" y="1675"/>
         </scene>
         <!--Compose a Post-->
         <scene sceneID="8yX-h6-lN9">
@@ -418,13 +541,38 @@
             </objects>
             <point key="canvasLocation" x="4004" y="873"/>
         </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="x7s-fA-SQj">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="z7o-os-hQ5" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="apV-pe-gGZ">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="cRq-wp-yDg" kind="relationship" relationship="rootViewController" id="FwZ-6G-nj8"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="a8M-wh-Zqn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-297" y="1675"/>
+        </scene>
     </scenes>
     <resources>
+        <image name="person.fill" catalog="system" width="128" height="120"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray3Color">
+            <color red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/CapstoneProject/View Controllers/AnsweringViewController.h
+++ b/CapstoneProject/View Controllers/AnsweringViewController.h
@@ -1,0 +1,16 @@
+//
+//  AnsweringViewController.h
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 7/20/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AnsweringViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CapstoneProject/View Controllers/AnsweringViewController.m
+++ b/CapstoneProject/View Controllers/AnsweringViewController.m
@@ -1,0 +1,26 @@
+//
+//  AnsweringViewController.m
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 7/20/22.
+//
+
+#import "AnsweringViewController.h"
+
+@interface AnsweringViewController ()
+
+@end
+
+@implementation AnsweringViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+- (IBAction)didTapCancel:(id)sender {
+    [self dismissViewControllerAnimated:true completion:nil];
+}
+
+
+@end

--- a/CapstoneProject/View Controllers/PostDetailsViewController.h
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.h
@@ -6,6 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "Post.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UILabel *nameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;
 @property (weak, nonatomic) IBOutlet UILabel *descriptionLabel;
-
+@property (strong, nonatomic) Post *postInfo;
 
 @end
 

--- a/CapstoneProject/View Controllers/PostDetailsViewController.h
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.h
@@ -1,0 +1,23 @@
+//
+//  PostDetailsViewController.h
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 7/20/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PostDetailsViewController : UIViewController
+
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
+@property (weak, nonatomic) IBOutlet UIImageView *profileImage;
+@property (weak, nonatomic) IBOutlet UILabel *nameLabel;
+@property (weak, nonatomic) IBOutlet UILabel *dateLabel;
+@property (weak, nonatomic) IBOutlet UILabel *descriptionLabel;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -1,0 +1,31 @@
+//
+//  PostDetailsViewController.m
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 7/20/22.
+//
+
+#import "PostDetailsViewController.h"
+
+@interface PostDetailsViewController ()
+
+@end
+
+@implementation PostDetailsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+@end

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -19,6 +19,7 @@
 }
 
 /*
+TODO: pass question data to answering view
 #pragma mark - Navigation
 
 // In a storyboard-based application, you will often want to do a little preparation before navigation

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -96,6 +96,7 @@
         ComposeViewController *composeController = (ComposeViewController*)navigationController.topViewController;
         composeController.delegate = self;
     }
+    // TODO: pass post information to details view
 }
 
 @end


### PR DESCRIPTION
### Context
This PR lets the user click on any of the posts cells on the feed to view its details (the contents in the details themselves have yet to be implemented). The user can also click the button for answering the question on the details screen, which leads a user to a blank screen with a cancel button for now. The cancel button can be used to go back to the details view.

### Test plan
1. Run the simulator, then click the login button to login with Facebook credentials.
2. After seeing the Home Screen with posts, press on any of the post cells on the feed
3. The user should see a screen with different visual components needed to display the details of the post.
4. Click the “Answer this Question” button
5. After seeing a blank screen, click on the “Cancel” button at the top left
6. The user should be back at the post details page.

### MVP features implemented
This PR is the first part of the “Comment on posts by mapping each Facebook post to an array of comments using a database” Stretch feature, except I am not planning to use the database for mapping anymore. I will update the Stretch features accordingly after this PR.

https://user-images.githubusercontent.com/107252243/180103436-7dffe61c-3a40-4f93-aec9-c28a2e60538c.mov
