### PR TITLE
Current course posts

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -59,29 +59,26 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="321"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IC3-N2-n4M">
-                                                    <rect key="frame" x="13" y="17.5" width="381" height="27"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IC3-N2-n4M">
+                                                    <rect key="frame" x="13" y="18" width="388" height="27"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" secondItem="IC3-N2-n4M" secondAttribute="height" multiplier="127:9" id="QkM-Vx-1kZ"/>
+                                                        <constraint firstAttribute="width" secondItem="IC3-N2-n4M" secondAttribute="height" multiplier="388:27" id="vAB-Pa-317"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bgV-G6-RZz">
-                                                    <rect key="frame" x="13" y="62.5" width="97" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bgV-G6-RZz">
+                                                    <rect key="frame" x="13" y="63" width="225" height="21"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="bgV-G6-RZz" secondAttribute="height" multiplier="75:7" id="reW-ug-NYW"/>
+                                                    </constraints>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wA0-2E-frI">
-                                                    <rect key="frame" x="234" y="62.5" width="36" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" systemColor="systemGrayColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="TS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VbD-iK-BxT">
-                                                    <rect key="frame" x="357" y="63" width="44" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="17h" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VbD-iK-BxT">
+                                                    <rect key="frame" x="350" y="63" width="51" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
@@ -92,24 +89,30 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="06/20/22" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wA0-2E-frI">
+                                                    <rect key="frame" x="264" y="63" width="70" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="systemGrayColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="bottom" constant="18.5" id="0IX-Ck-EAz"/>
-                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="top" secondItem="IC3-N2-n4M" secondAttribute="bottom" constant="18" id="1m4-3I-IPl"/>
-                                                <constraint firstItem="wA0-2E-frI" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="trailing" constant="124" id="6QP-L1-FHn"/>
-                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="trailing" secondItem="IC3-N2-n4M" secondAttribute="trailing" constant="7" id="HFr-F6-TiS"/>
-                                                <constraint firstAttribute="trailing" secondItem="IC3-N2-n4M" secondAttribute="trailing" constant="20" symbolic="YES" id="NAa-2f-FWs"/>
-                                                <constraint firstItem="wA0-2E-frI" firstAttribute="bottom" secondItem="bgV-G6-RZz" secondAttribute="bottom" id="Ppu-yq-Xwb"/>
-                                                <constraint firstItem="IC3-N2-n4M" firstAttribute="top" secondItem="TEw-vj-WUp" secondAttribute="top" constant="17.5" id="YCn-Ja-dIN"/>
-                                                <constraint firstItem="wA0-2E-frI" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="top" id="aVV-Di-ycb"/>
-                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="trailing" secondItem="VbD-iK-BxT" secondAttribute="trailing" id="bJV-p4-dR5"/>
-                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="top" secondItem="wA0-2E-frI" secondAttribute="top" id="dh5-wY-aSi"/>
-                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="bottom" secondItem="wA0-2E-frI" secondAttribute="bottom" id="fON-3g-Pp4"/>
-                                                <constraint firstAttribute="bottom" secondItem="aX1-Aq-cAU" secondAttribute="bottom" constant="22" id="ifd-T1-ACh"/>
-                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="leading" id="oMN-Ry-psg"/>
-                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="leading" secondItem="IC3-N2-n4M" secondAttribute="leading" id="pr6-Qt-ktM"/>
-                                                <constraint firstItem="IC3-N2-n4M" firstAttribute="leading" secondItem="TEw-vj-WUp" secondAttribute="leading" constant="13" id="tBN-4h-jc7"/>
-                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="leading" secondItem="wA0-2E-frI" secondAttribute="trailing" constant="87" id="woy-Mx-gqZ"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="top" secondItem="wA0-2E-frI" secondAttribute="top" id="5CH-ha-4lc"/>
+                                                <constraint firstItem="IC3-N2-n4M" firstAttribute="top" secondItem="TEw-vj-WUp" secondAttribute="top" constant="18" id="6Ff-Na-Ntp"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="bottom" secondItem="wA0-2E-frI" secondAttribute="bottom" id="6cO-o1-Y1s"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="leading" secondItem="wA0-2E-frI" secondAttribute="trailing" constant="16" id="GJJ-QI-VsJ"/>
+                                                <constraint firstAttribute="bottom" secondItem="aX1-Aq-cAU" secondAttribute="bottom" constant="22" id="GRb-Oh-fnF"/>
+                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="leading" id="OJe-Km-i5b"/>
+                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="bottom" constant="18" id="XGB-n1-Riy"/>
+                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="trailing" secondItem="VbD-iK-BxT" secondAttribute="trailing" id="Yqt-4U-s7Z"/>
+                                                <constraint firstItem="wA0-2E-frI" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="top" id="Zcn-JL-bcX"/>
+                                                <constraint firstItem="wA0-2E-frI" firstAttribute="bottom" secondItem="bgV-G6-RZz" secondAttribute="bottom" id="cBg-FZ-Cst"/>
+                                                <constraint firstAttribute="trailing" secondItem="IC3-N2-n4M" secondAttribute="trailing" constant="13" id="iEY-CB-f2a"/>
+                                                <constraint firstItem="wA0-2E-frI" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="trailing" constant="26" id="ms0-Lg-99k"/>
+                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="top" secondItem="IC3-N2-n4M" secondAttribute="bottom" constant="18" id="rDn-Xe-Uzr"/>
+                                                <constraint firstItem="IC3-N2-n4M" firstAttribute="leading" secondItem="TEw-vj-WUp" secondAttribute="leading" constant="13" id="rg0-5Q-LFj"/>
+                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="leading" secondItem="IC3-N2-n4M" secondAttribute="leading" id="vb3-0U-XgO"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="trailing" secondItem="IC3-N2-n4M" secondAttribute="trailing" id="zje-lT-PAJ"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -52,52 +52,64 @@
                                 <rect key="frame" x="0.0" y="32" width="414" height="810"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="PostCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PostCell" rowHeight="199" id="LWb-8h-ubS" customClass="PostCell">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="199"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="PostCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PostCell" rowHeight="321" id="LWb-8h-ubS" customClass="PostCell">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="321"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LWb-8h-ubS" id="TEw-vj-WUp">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="199"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="321"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IC3-N2-n4M">
+                                                    <rect key="frame" x="13" y="17.5" width="381" height="27"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="IC3-N2-n4M" secondAttribute="height" multiplier="127:9" id="QkM-Vx-1kZ"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bgV-G6-RZz">
-                                                    <rect key="frame" x="13" y="11" width="97" height="20.5"/>
+                                                    <rect key="frame" x="13" y="62.5" width="97" height="21"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wA0-2E-frI">
-                                                    <rect key="frame" x="139" y="11" width="36" height="20.5"/>
+                                                    <rect key="frame" x="234" y="62.5" width="36" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="TS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VbD-iK-BxT">
-                                                    <rect key="frame" x="191" y="11" width="210" height="20.5"/>
+                                                    <rect key="frame" x="357" y="63" width="44" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aX1-Aq-cAU">
-                                                    <rect key="frame" x="13" y="36" width="388" height="152"/>
+                                                    <rect key="frame" x="13" y="102" width="388" height="197"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="top" secondItem="wA0-2E-frI" secondAttribute="top" id="0Vv-k2-G6b"/>
-                                                <constraint firstAttribute="bottom" secondItem="aX1-Aq-cAU" secondAttribute="bottom" constant="11" id="0vW-oC-y8t"/>
-                                                <constraint firstAttribute="trailing" secondItem="VbD-iK-BxT" secondAttribute="trailing" constant="13" id="1Ua-eU-6uy"/>
-                                                <constraint firstItem="wA0-2E-frI" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="trailing" constant="29" id="2tZ-N4-mNO"/>
-                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="leading" id="DHE-kl-AY6"/>
-                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="bottom" constant="4.5" id="Hvt-pG-g6R"/>
-                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="trailing" secondItem="VbD-iK-BxT" secondAttribute="trailing" id="JvT-W4-zRM"/>
-                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="leading" secondItem="TEw-vj-WUp" secondAttribute="leading" constant="13" id="M7C-EA-g4b"/>
-                                                <constraint firstItem="wA0-2E-frI" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="top" id="V6A-zE-PgQ"/>
-                                                <constraint firstItem="wA0-2E-frI" firstAttribute="bottom" secondItem="bgV-G6-RZz" secondAttribute="bottom" id="sUA-YU-kAh"/>
-                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="leading" secondItem="wA0-2E-frI" secondAttribute="trailing" constant="16" id="tEU-6x-oE6"/>
-                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="top" secondItem="TEw-vj-WUp" secondAttribute="top" constant="11" id="vpg-Jl-ic2"/>
-                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="bottom" secondItem="wA0-2E-frI" secondAttribute="bottom" id="ylL-qd-RE1"/>
+                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="bottom" constant="18.5" id="0IX-Ck-EAz"/>
+                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="top" secondItem="IC3-N2-n4M" secondAttribute="bottom" constant="18" id="1m4-3I-IPl"/>
+                                                <constraint firstItem="wA0-2E-frI" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="trailing" constant="124" id="6QP-L1-FHn"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="trailing" secondItem="IC3-N2-n4M" secondAttribute="trailing" constant="7" id="HFr-F6-TiS"/>
+                                                <constraint firstAttribute="trailing" secondItem="IC3-N2-n4M" secondAttribute="trailing" constant="20" symbolic="YES" id="NAa-2f-FWs"/>
+                                                <constraint firstItem="wA0-2E-frI" firstAttribute="bottom" secondItem="bgV-G6-RZz" secondAttribute="bottom" id="Ppu-yq-Xwb"/>
+                                                <constraint firstItem="IC3-N2-n4M" firstAttribute="top" secondItem="TEw-vj-WUp" secondAttribute="top" constant="17.5" id="YCn-Ja-dIN"/>
+                                                <constraint firstItem="wA0-2E-frI" firstAttribute="top" secondItem="bgV-G6-RZz" secondAttribute="top" id="aVV-Di-ycb"/>
+                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="trailing" secondItem="VbD-iK-BxT" secondAttribute="trailing" id="bJV-p4-dR5"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="top" secondItem="wA0-2E-frI" secondAttribute="top" id="dh5-wY-aSi"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="bottom" secondItem="wA0-2E-frI" secondAttribute="bottom" id="fON-3g-Pp4"/>
+                                                <constraint firstAttribute="bottom" secondItem="aX1-Aq-cAU" secondAttribute="bottom" constant="22" id="ifd-T1-ACh"/>
+                                                <constraint firstItem="aX1-Aq-cAU" firstAttribute="leading" secondItem="bgV-G6-RZz" secondAttribute="leading" id="oMN-Ry-psg"/>
+                                                <constraint firstItem="bgV-G6-RZz" firstAttribute="leading" secondItem="IC3-N2-n4M" secondAttribute="leading" id="pr6-Qt-ktM"/>
+                                                <constraint firstItem="IC3-N2-n4M" firstAttribute="leading" secondItem="TEw-vj-WUp" secondAttribute="leading" constant="13" id="tBN-4h-jc7"/>
+                                                <constraint firstItem="VbD-iK-BxT" firstAttribute="leading" secondItem="wA0-2E-frI" secondAttribute="trailing" constant="87" id="woy-Mx-gqZ"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -105,6 +117,7 @@
                                             <outlet property="nameLabel" destination="bgV-G6-RZz" id="Fgo-Gg-Naa"/>
                                             <outlet property="postText" destination="aX1-Aq-cAU" id="yAM-Od-kj0"/>
                                             <outlet property="timestampLabel" destination="VbD-iK-BxT" id="eFF-Nv-lBj"/>
+                                            <outlet property="titleLabel" destination="IC3-N2-n4M" id="sUb-0t-PgX"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -152,7 +165,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9Vf-R5-9fS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1249" y="873"/>
+            <point key="canvasLocation" x="-1249.2753623188407" y="872.54464285714278"/>
         </scene>
         <!--Compose a Post-->
         <scene sceneID="8yX-h6-lN9">
@@ -163,19 +176,27 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Write something..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Z0y-oD-QlO">
-                                <rect key="frame" x="29" y="69" width="355" height="282"/>
+                                <rect key="frame" x="20" y="133" width="350" height="282"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Title" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="axT-Pa-5g3">
+                                <rect key="frame" x="20" y="79" width="350" height="33"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btF-V8-ggi">
-                                <rect key="frame" x="307" y="379" width="58" height="35"/>
+                                <rect key="frame" x="310" y="437" width="60" height="36"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Post">
-                                    <fontDescription key="titleFontDescription" type="system" pointSize="17"/>
+                                    <fontDescription key="titleFontDescription" type="system" pointSize="18"/>
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="didTapPost:" destination="FuT-sU-6aw" eventType="touchUpInside" id="Xht-9v-Cjs"/>
@@ -200,11 +221,12 @@
                     </navigationItem>
                     <connections>
                         <outlet property="postText" destination="Z0y-oD-QlO" id="ROQ-h8-Bt6"/>
+                        <outlet property="titleText" destination="axT-Pa-5g3" id="Ia2-Wg-4vb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cFx-Hf-VhK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="633" y="873"/>
+            <point key="canvasLocation" x="630.43478260869574" y="872.54464285714278"/>
         </scene>
         <!--Game View Controller-->
         <scene sceneID="HmM-Tu-y9p">

--- a/CapstoneProject/Models/Post.h
+++ b/CapstoneProject/Models/Post.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Post : NSObject
 
-@property (nonatomic, strong) NSString *textContent; // Text content of post
+@property (nonatomic, strong) NSMutableString *textContent; // Text content of post
 @property (nonatomic, strong) NSString *user_id; // App-scoped id of user
 @property (nonatomic, strong) NSString *post_id; // App-scoped id of user
 @property (nonatomic, strong) NSString *user_name; // App-scoped id of user

--- a/CapstoneProject/Models/Post.h
+++ b/CapstoneProject/Models/Post.h
@@ -11,7 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Post : NSObject
 
+@property (nonatomic, strong) NSMutableString *titleContent; // Title of post
 @property (nonatomic, strong) NSMutableString *textContent; // Text content of post
+@property (nonatomic, strong) NSMutableString *courses; // Courses, separated by comma
 @property (nonatomic, strong) NSString *user_id; // App-scoped id of user
 @property (nonatomic, strong) NSString *post_id; // App-scoped id of user
 @property (nonatomic, strong) NSString *user_name; // App-scoped id of user

--- a/CapstoneProject/Models/Post.m
+++ b/CapstoneProject/Models/Post.m
@@ -17,7 +17,18 @@
         NSLog(@"%@", dictionary);
         self.user_id = dictionary[@"from"][@"id"];
         self.user_name = dictionary[@"from"][@"name"];
-        self.textContent = dictionary[@"message"];
+        
+        NSLog(@"This is my message: %@", dictionary[@"message"]);
+        NSArray *arrayOfComponents = [dictionary[@"message"] componentsSeparatedByString:@"/0\n\n"];
+        if ([arrayOfComponents count] == 3) {
+            self.titleContent = arrayOfComponents[0];
+            self.textContent = arrayOfComponents[1];
+            self.courses = arrayOfComponents[2];
+        } else {
+            self.titleContent = [NSMutableString stringWithString:@""];
+            self.textContent = [NSMutableString stringWithString:@""];
+        }
+        
         self.post_id = dictionary[@"id"];
         
         NSString *createdAtOriginalString = dictionary[@"created_time"];
@@ -40,7 +51,9 @@
     for (NSDictionary *dictionary in dictionaries) {
         NSLog(@"postsWithArray dictionary: %@", dictionary);
         Post *post = [[Post alloc] initWithDictionary:dictionary];
-        [posts addObject:post];
+        if (![post.titleContent isEqualToString:@""] && ![post.textContent isEqualToString: @""]) {
+            [posts addObject:post];
+        }
     }
     NSLog(@"postsWithArray return value: %@", posts);
     return posts;

--- a/CapstoneProject/Models/Post.m
+++ b/CapstoneProject/Models/Post.m
@@ -36,10 +36,13 @@
 
 + (NSMutableArray *)postsWithArray:(NSArray *)dictionaries {
     NSMutableArray *posts = [NSMutableArray array];
+    NSLog(@"postsWithArray posts: %@", posts);
     for (NSDictionary *dictionary in dictionaries) {
+        NSLog(@"postsWithArray dictionary: %@", dictionary);
         Post *post = [[Post alloc] initWithDictionary:dictionary];
         [posts addObject:post];
     }
+    NSLog(@"postsWithArray return value: %@", posts);
     return posts;
 }
 

--- a/CapstoneProject/Models/Post.m
+++ b/CapstoneProject/Models/Post.m
@@ -17,8 +17,8 @@
         NSLog(@"%@", dictionary);
         self.user_id = dictionary[@"from"][@"id"];
         self.user_name = dictionary[@"from"][@"name"];
-        
-        NSLog(@"This is my message: %@", dictionary[@"message"]);
+        self.post_id = dictionary[@"id"];
+
         NSArray *arrayOfComponents = [dictionary[@"message"] componentsSeparatedByString:@"/0\n\n"];
         if ([arrayOfComponents count] == 3) {
             self.titleContent = arrayOfComponents[0];
@@ -28,8 +28,6 @@
             self.titleContent = [NSMutableString stringWithString:@""];
             self.textContent = [NSMutableString stringWithString:@""];
         }
-        
-        self.post_id = dictionary[@"id"];
         
         NSString *createdAtOriginalString = dictionary[@"created_time"];
         NSDateFormatter *formatter = [[NSDateFormatter alloc] init];

--- a/CapstoneProject/View Controllers/ComposeViewController.m
+++ b/CapstoneProject/View Controllers/ComposeViewController.m
@@ -11,6 +11,7 @@
 #import "Parse/Parse.h"
 
 @interface ComposeViewController ()
+@property (weak, nonatomic) IBOutlet UITextView *titleText;
 @property (weak, nonatomic) IBOutlet UITextView *postText;
 
 @end
@@ -19,7 +20,10 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
+    self.titleText.layer.borderWidth = 1.0;
+    self.titleText.layer.borderColor = [[UIColor blackColor] CGColor];
+    self.postText.layer.borderWidth = 1.0;
+    self.postText.layer.borderColor = [[UIColor blackColor] CGColor];
 }
 
 - (IBAction)didTapCancel:(id)sender {
@@ -34,10 +38,10 @@
     NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
     NSString *courseId = [saved stringForKey:@"currentCourse"];
     
-    NSString *messageWithDelimiter = [NSString stringWithFormat:@"%@%@%@", self.postText.text, @"<?/!,,,,,,,,,,..,,,!>", courseId];
+    NSString *messageWithDelimiters = [NSString stringWithFormat:@"%@%@%@%@%@", self.titleText.text, @"/0\n\n", self.postText.text, @"/0\n\n", courseId];
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
                                   initWithGraphPath:@"/425184976239857/feed"
-                                  parameters:@{ @"message": messageWithDelimiter}
+                                  parameters:@{ @"message": messageWithDelimiters}
                                   HTTPMethod:@"POST"];
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {

--- a/CapstoneProject/View Controllers/ComposeViewController.m
+++ b/CapstoneProject/View Controllers/ComposeViewController.m
@@ -31,9 +31,13 @@
 }
 
 -(void)composePost {
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    NSString *courseId = [saved stringForKey:@"currentCourse"];
+    
+    NSString *messageWithDelimiter = [NSString stringWithFormat:@"%@%@%@", self.postText.text, @"<?/!,,,,,,,,,,..,,,!>", courseId];
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
                                   initWithGraphPath:@"/425184976239857/feed"
-                                  parameters:@{ @"message": self.postText.text,}
+                                  parameters:@{ @"message": messageWithDelimiter}
                                   HTTPMethod:@"POST"];
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
@@ -43,23 +47,6 @@
                     NSLog(@"Error getting post: %@", err.localizedDescription);
                 } else {
                     NSLog(@"Success!");
-                    
-                    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-                    NSString *courseId = [saved stringForKey:@"currentCourse"];
-                    NSLog(@"Current course: %@", courseId);
-                    
-                    PFObject *newPost = [PFObject objectWithClassName:@"Post"];
-                    newPost[@"post_id"] = result[@"id"];
-                    newPost[@"course_objectId"] = courseId;
-                    //gameScore[@"comments"] = [[NSMutableArray alloc] init];
-                    [newPost saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-                        if (succeeded) {
-                            NSLog(@"Object saved!");
-                        } else {
-                            NSLog(@"Error: %@", error.description);
-                        }
-                    }];
-                    
                     [self dismissViewControllerAnimated:YES completion:nil];
                     [self.delegate didPost:post];
                 }

--- a/CapstoneProject/View Controllers/ComposeViewController.m
+++ b/CapstoneProject/View Controllers/ComposeViewController.m
@@ -8,6 +8,7 @@
 #import "ComposeViewController.h"
 #import "FBSDKCoreKit/FBSDKCoreKit.h"
 #import "Post.h"
+#import "Parse/Parse.h"
 
 @interface ComposeViewController ()
 @property (weak, nonatomic) IBOutlet UITextView *postText;
@@ -42,6 +43,23 @@
                     NSLog(@"Error getting post: %@", err.localizedDescription);
                 } else {
                     NSLog(@"Success!");
+                    
+                    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+                    NSString *courseId = [saved stringForKey:@"currentCourse"];
+                    NSLog(@"Current course: %@", courseId);
+                    
+                    PFObject *newPost = [PFObject objectWithClassName:@"Post"];
+                    newPost[@"post_id"] = result[@"id"];
+                    newPost[@"course_objectId"] = courseId;
+                    //gameScore[@"comments"] = [[NSMutableArray alloc] init];
+                    [newPost saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+                        if (succeeded) {
+                            NSLog(@"Object saved!");
+                        } else {
+                            NSLog(@"Error: %@", error.description);
+                        }
+                    }];
+                    
                     [self dismissViewControllerAnimated:YES completion:nil];
                     [self.delegate didPost:post];
                 }

--- a/CapstoneProject/View Controllers/FBLoginViewController.m
+++ b/CapstoneProject/View Controllers/FBLoginViewController.m
@@ -26,14 +26,15 @@
 
 -(void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    NSLog(@"Hi!");
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    [saved setObject:@"fYiXfSzdT9" forKey:@"currentCourse"];
     
     // if the user is already logged in
     if ([FBSDKAccessToken currentAccessToken] != nil) {
         NSLog(@"User ID = %@", [FBSDKAccessToken currentAccessToken].userID);
         
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-        UITabBarController *rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"loginSuccessPage"]; // loginSuccessPage
+        UITabBarController *rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"loginSuccessPage"];
         [self showViewController:rootViewController sender:nil];
     }
 }

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -12,6 +12,7 @@
 #import "PostCell.h"
 #import "Post.h"
 #import "ComposeViewController.h"
+#import "Parse/Parse.h"
 
 @interface QuestionFeedViewController () <ComposeViewControllerDelegate, UITableViewDelegate, UITableViewDataSource>
 
@@ -58,9 +59,26 @@
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
             NSLog(@"%@", result[@"data"]);
-            NSLog(@"%@",
-                  [result[@"data"] class]);
-            self.postArray = [Post postsWithArray:result[@"data"]];
+            NSLog(@"%@", [result[@"data"] class]);
+            //self.postArray = [Post postsWithArray:result[@"data"]];
+            NSMutableArray *allPosts = [Post postsWithArray:result[@"data"]];
+            NSInteger numPosts = [allPosts count];
+            
+            NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+            NSString *course_id = [saved stringForKey:@"currentCourse"];
+            [self getPostsFromCourseWithCompletion:course_id completion:^(NSArray *postsFromCourse, NSError *error) {
+                if (error) {
+                    NSLog(@"Error: %@", error.localizedDescription);
+                } else {
+                    // for every post in postsFromCourse
+                    //     GET post from the post_id field
+                    //     (don't need this outside get request in this case)
+                    for (NSInteger i = 0; i < numPosts; i++) {
+                        //if (allPosts[i][@"id"])
+                    }
+                }
+            }];
+            
             [self.tableView reloadData];
         } else {
             NSLog(@"Error posting to feed: %@", error.localizedDescription);
@@ -68,6 +86,22 @@
         [self.refreshControl endRefreshing];
     }];
     NSLog(@"%@", [FBSDKAccessToken currentAccessToken]);
+}
+
+- (void)getPostsFromCourseWithCompletion:(NSString *)course_id completion:(void(^)(NSArray *posts, NSError *error))completion {
+    PFQuery *query = [PFQuery queryWithClassName:@"Post"];
+    [query whereKey:@"course_objectId" equalTo:course_id];
+    // TODO: add limit/load more posts
+
+    // fetch data asynchronously
+    [query findObjectsInBackgroundWithBlock:^(NSArray *result, NSError *error) {
+        if (result != nil) {
+            NSMutableArray *posts = [NSMutableArray arrayWithArray:result];
+            completion(posts, nil);
+        } else {
+            completion(nil, error);
+        }
+    }];
 }
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -12,6 +12,7 @@
 #import "PostCell.h"
 #import "Post.h"
 #import "ComposeViewController.h"
+#import "SelectCourseViewController.h"
 #import "Parse/Parse.h"
 
 @interface QuestionFeedViewController () <ComposeViewControllerDelegate, UITableViewDelegate, UITableViewDataSource>
@@ -57,25 +58,17 @@
     
     [self getAllPostsWithCompletion:^(NSMutableArray *posts, NSError *error) {
         if (!error) {
-            NSLog(@"HELLO!");
             NSMutableArray *postsToBeQueried = [NSMutableArray array];
             for (Post *post in posts) {
-                NSLog(@"textcontent: %@", post.textContent);
                 NSArray *arrayOfComponents = [post.textContent componentsSeparatedByString:@"<?/!,,,,,,,,,,..,,,!>"];
                 if ([arrayOfComponents count] >= 2) {
-                    NSLog(@"first: %@", arrayOfComponents[0]);
-                    NSLog(@"second: %@", arrayOfComponents[1]);
                     if ([arrayOfComponents[1] isEqualToString:course_id]) {
-                        
-                        Post *p = post;
-                        p.textContent = arrayOfComponents[0];
-                        [postsToBeQueried addObject:p];
-                        NSLog(@"postsToBeQueried: %@", postsToBeQueried);
+                        post.textContent = arrayOfComponents[0];
+                        [postsToBeQueried addObject:post];
                     }
                 }
             }
             self.postArray = postsToBeQueried;
-            NSLog(@"postArray in fetchPosts: %@", postsToBeQueried);
             [self.tableView reloadData];
         } else {
             NSLog(@"Error: %@", error.localizedDescription);

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -50,45 +50,70 @@
     self.view.window.rootViewController = loginViewController; // substitute, less elegant
 }
 
--(void)fetchPosts {
+- (void)fetchPosts {
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    NSString *course_id = [saved stringForKey:@"currentCourse"];
+    
+    [self getCoursePostsWithCompletion:course_id completion:^(NSArray *posts, NSError *error) {
+        if (!error) {
+            self.postArray = [Post postsWithArray:posts];
+            NSLog(@"postArray in fetchPosts: %@", posts);
+            [self.tableView reloadData];
+            [self.refreshControl endRefreshing];
+        } else {
+            NSLog(@"Error: %@", error.localizedDescription);
+        }
+    }];
+}
+
+- (void)getCoursePostsWithCompletion:(NSString *)course_id completion:(void(^)(NSArray *posts, NSError *error))completion {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSMutableArray *allPosts = [[NSMutableArray alloc] init];
+        [self getPostMappingsFromCourseWithCompletion:course_id completion:^(NSArray *postMappingsFromCourse, NSError *error) {
+            if (!error) {
+                for (NSDictionary *dict in postMappingsFromCourse) {
+                    NSLog(@"dict: %@", dict);
+                    NSLog(@"id of dict: %@", dict[@"post_id"]);
+                    
+                    [self getPostFromIdWithCompletion:dict[@"post_id"] completion:^(NSDictionary *post, NSError *error) {
+                        if (!error) {
+                            [allPosts addObject:post];
+                            NSLog(@"allPosts so far = %@", allPosts);
+                        } else {
+                            NSLog(@"Error getting post: %@", error.localizedDescription);
+                            completion(nil, error);
+                        }
+                    }];
+                }
+                NSLog(@"allPosts final = %@", allPosts);
+            } else {
+                NSLog(@"Error: %@", error.localizedDescription);
+            }
+        }];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSLog(@"allPosts after dispatch block = %@", allPosts);
+            completion(allPosts, nil);
+        });
+    });
+}
+
+- (void)getPostFromIdWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion {
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-                                  initWithGraphPath:@"/425184976239857/feed"
+                                  initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
                                   parameters:@{ @"fields": @"from, created_time, message"}
                                   HTTPMethod:@"GET"];
     
     [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
         if (!error) {
-            NSLog(@"%@", result[@"data"]);
-            NSLog(@"%@", [result[@"data"] class]);
-            //self.postArray = [Post postsWithArray:result[@"data"]];
-            NSMutableArray *allPosts = [Post postsWithArray:result[@"data"]];
-            NSInteger numPosts = [allPosts count];
-            
-            NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-            NSString *course_id = [saved stringForKey:@"currentCourse"];
-            [self getPostsFromCourseWithCompletion:course_id completion:^(NSArray *postsFromCourse, NSError *error) {
-                if (error) {
-                    NSLog(@"Error: %@", error.localizedDescription);
-                } else {
-                    // for every post in postsFromCourse
-                    //     GET post from the post_id field
-                    //     (don't need this outside get request in this case)
-                    for (NSInteger i = 0; i < numPosts; i++) {
-                        //if (allPosts[i][@"id"])
-                    }
-                }
-            }];
-            
-            [self.tableView reloadData];
+            NSDictionary *post = [NSDictionary dictionaryWithDictionary:result];
+            completion(post, nil);
         } else {
-            NSLog(@"Error posting to feed: %@", error.localizedDescription);
+            completion(nil, error);
         }
-        [self.refreshControl endRefreshing];
     }];
-    NSLog(@"%@", [FBSDKAccessToken currentAccessToken]);
 }
 
-- (void)getPostsFromCourseWithCompletion:(NSString *)course_id completion:(void(^)(NSArray *posts, NSError *error))completion {
+- (void)getPostMappingsFromCourseWithCompletion:(NSString *)course_id completion:(void(^)(NSArray *posts, NSError *error))completion {
     PFQuery *query = [PFQuery queryWithClassName:@"Post"];
     [query whereKey:@"course_objectId" equalTo:course_id];
     // TODO: add limit/load more posts
@@ -97,6 +122,7 @@
     [query findObjectsInBackgroundWithBlock:^(NSArray *result, NSError *error) {
         if (result != nil) {
             NSMutableArray *posts = [NSMutableArray arrayWithArray:result];
+            NSLog(@"Selected Posts: %@", posts);
             completion(posts, nil);
         } else {
             completion(nil, error);

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -60,12 +60,8 @@
         if (!error) {
             NSMutableArray *postsToBeQueried = [NSMutableArray array];
             for (Post *post in posts) {
-                NSArray *arrayOfComponents = [post.textContent componentsSeparatedByString:@"<?/!,,,,,,,,,,..,,,!>"];
-                if ([arrayOfComponents count] >= 2) {
-                    if ([arrayOfComponents[1] isEqualToString:course_id]) {
-                        post.textContent = arrayOfComponents[0];
-                        [postsToBeQueried addObject:post];
-                    }
+                if ([post.courses isEqualToString:course_id]) {
+                    [postsToBeQueried addObject:post];
                 }
             }
             self.postArray = postsToBeQueried;

--- a/CapstoneProject/View Controllers/SelectCourseViewController.m
+++ b/CapstoneProject/View Controllers/SelectCourseViewController.m
@@ -74,4 +74,12 @@
     return self.courseArray.count;
 }
 
+/*
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSString *objectId = self.courseArray[indexPath.row][@"objectId"];
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    [saved setObject:objectId forKey:@"currentCourse"];
+}
+ */
+
 @end

--- a/CapstoneProject/View Controllers/SelectCourseViewController.m
+++ b/CapstoneProject/View Controllers/SelectCourseViewController.m
@@ -52,16 +52,6 @@
     }];
 }
 
-/*
-#pragma mark - Navigation
- 
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
-
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
     CourseCell *cell = [tableView dequeueReusableCellWithIdentifier:@"CourseCell"];
 
@@ -73,13 +63,5 @@
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return self.courseArray.count;
 }
-
-/*
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSString *objectId = self.courseArray[indexPath.row][@"objectId"];
-    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-    [saved setObject:objectId forKey:@"currentCourse"];
-}
- */
 
 @end

--- a/CapstoneProject/Views/PostCell.h
+++ b/CapstoneProject/Views/PostCell.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PostCell : UITableViewCell
 
 @property (nonatomic, strong) Post *post;
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 @property (weak, nonatomic) IBOutlet UILabel *nameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *postText;
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;

--- a/CapstoneProject/Views/PostCell.m
+++ b/CapstoneProject/Views/PostCell.m
@@ -23,6 +23,7 @@
 -(void)setPost:(Post *)post {
     _post = post;
     
+    self.titleLabel.text = post.titleContent;
     self.nameLabel.text = post.user_name;
     self.postText.text = post.textContent;
     self.dateLabel.text = post.post_createdAt;

--- a/CapstoneProject/Views/PostCell.m
+++ b/CapstoneProject/Views/PostCell.m
@@ -13,14 +13,13 @@
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    // Initialization code
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
 }
 
--(void)setPost:(Post *)post {
+- (void)setPost:(Post *)post {
     _post = post;
     
     self.titleLabel.text = post.titleContent;


### PR DESCRIPTION
### Context
This functionality adds on to #14, which implemented post-to-course_id mappings. The user can now include a title on their post, and the app can now display the posts for a specific course that corresponds to the course_id stored locally. The question title, question body, and course_id are stored in the “message” field of the Facebook Group post, in the format “QuestionTitle/0\n\nQuestionBody/0\n\nCourseTag1,CourseTag2” with ‘/0’ as the delimiter and the newlines to make the posts on the Facebook Group itself more presentable.

I have yet to add the functionality for selecting between courses, but will PR this part first to avoid PRing too much code at once.

### Test plan
1. Run the simulator, then click the login button to login with Facebook credentials.
2. After seeing the Home Screen with posts, press on the right navigation bar button that reads “Post”
3. Write the question title in the “Title” field and question body in the “Write something… “ field, then tap “Post”.
4. You will see the timeline pop up, with the new post at the top.
5. Go to the Facebook Group that stores these posts, and see that there is a new post formatted in the format mentioned in the Context.

### MVP features implemented
This PR is part of the “Select a course from a list to view its feed” feature.

https://user-images.githubusercontent.com/107252243/180103574-6c9e3b13-722d-4fe0-9c9e-91cd4981d78a.mov
