### PR TITLE
Select course and display

### DIFF
--- a/CapstoneProject/AppDelegate.m
+++ b/CapstoneProject/AppDelegate.m
@@ -48,6 +48,10 @@
     return handled;
 }
 
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 #pragma mark - UISceneSession lifecycle
 
 

--- a/CapstoneProject/View Controllers/FBLoginViewController.m
+++ b/CapstoneProject/View Controllers/FBLoginViewController.m
@@ -26,8 +26,6 @@
 
 -(void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-    [saved setObject:@"fYiXfSzdT9" forKey:@"currentCourse"];
     
     // if the user is already logged in
     if ([FBSDKAccessToken currentAccessToken] != nil) {

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -109,12 +109,8 @@
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-    NSString *course_id = [saved stringForKey:@"currentCourse"];
-    
     [self fetchPosts];
     [self.tableView reloadData];
-    NSLog(@"Current course id: %@", course_id);
 }
 
 

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -112,8 +112,8 @@
     NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
     NSString *course_id = [saved stringForKey:@"currentCourse"];
     
-    //[self fetchPosts];
-    //[self.tableView reloadData];
+    [self fetchPosts];
+    [self.tableView reloadData];
     NSLog(@"Current course id: %@", course_id);
 }
 

--- a/CapstoneProject/View Controllers/SelectCourseViewController.m
+++ b/CapstoneProject/View Controllers/SelectCourseViewController.m
@@ -69,9 +69,6 @@
     NSString *objectId = ((PFObject *) self.courseArray[indexPath.row]).objectId;
     NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
     [saved setObject:objectId forKey:@"currentCourse"];
-
-    
-    //QuestionFeedViewController *questionfeedvc = self.tabBarController.viewControllers[0];
     
     UIView * fromView = self.tabBarController.selectedViewController.view;
     UIView * toView = self.tabBarController.viewControllers[0].view;


### PR DESCRIPTION
### Description
This PR combines PR #16 (displaying the courses for a hard-coded course id) and #19 (selecting a course), so that the user can select a course in the course list be directly lead to the course’s feed. When a course is selected, the user can also compost a post so the post will appear in the course’s feed. Switching to a different course will no longer make this new post appear.

### Milestones
This feature completes and combines the implementations for the MVP features “Select a course from a list to view its feed”, “Display the user feed”, and “Compose a post and update the corresponding course feed”.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/180898589-c865d83c-519f-4f70-91c1-b265d22b785f.mov
