### PR TITLE
Comment to fb

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -308,6 +308,9 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Respond"/>
+                                <connections>
+                                    <action selector="didTapRespond:" destination="cRq-wp-yDg" eventType="touchUpInside" id="W2K-ZH-FGT"/>
+                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="2AA-nj-rcc"/>

--- a/CapstoneProject/View Controllers/AnsweringViewController.m
+++ b/CapstoneProject/View Controllers/AnsweringViewController.m
@@ -45,17 +45,6 @@
         if (!error) {
             NSLog(@"Success!");
             [self dismissViewControllerAnimated:YES completion:nil];
-            /*
-            [self getPostWithID:result[@"id"] completion:^(Post *post, NSError *err) {
-                if (err) {
-                    NSLog(@"Error getting post: %@", err.localizedDescription);
-                } else {
-                    NSLog(@"Success!");
-                    [self dismissViewControllerAnimated:YES completion:nil];
-                    //[self.delegate didPost:post];
-                }
-            }];
-             */
         } else {
             NSLog(@"Error posting to feed: %@", error.localizedDescription);
         }

--- a/CapstoneProject/View Controllers/AnsweringViewController.m
+++ b/CapstoneProject/View Controllers/AnsweringViewController.m
@@ -6,6 +6,7 @@
 //
 
 #import "AnsweringViewController.h"
+#import "FBSDKCoreKit/FBSDKCoreKit.h"
 
 @interface AnsweringViewController ()
 
@@ -26,6 +27,39 @@
 
 - (IBAction)didTapCancel:(id)sender {
     [self dismissViewControllerAnimated:true completion:nil];
+}
+
+- (IBAction)didTapRespond:(id)sender {
+    [self composeAnswer];
+}
+
+
+- (void)composeAnswer {
+    NSString *messageWithDelimiters = [NSString stringWithFormat:@"%@%@%@", self.answerText.text, @"/0\n\n", self.postToAnswerInfo.post_id];
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+                                  initWithGraphPath:@"/425184976239857/feed"
+                                  parameters:@{ @"message": messageWithDelimiters}
+                                  HTTPMethod:@"POST"];
+    
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        if (!error) {
+            NSLog(@"Success!");
+            [self dismissViewControllerAnimated:YES completion:nil];
+            /*
+            [self getPostWithID:result[@"id"] completion:^(Post *post, NSError *err) {
+                if (err) {
+                    NSLog(@"Error getting post: %@", err.localizedDescription);
+                } else {
+                    NSLog(@"Success!");
+                    [self dismissViewControllerAnimated:YES completion:nil];
+                    //[self.delegate didPost:post];
+                }
+            }];
+             */
+        } else {
+            NSLog(@"Error posting to feed: %@", error.localizedDescription);
+        }
+    }];
 }
 
 


### PR DESCRIPTION
Description
When a user selects a post to answer, the user can write a comment, and the comment will show up, along with the post id for the post it belongs to, on the Facebook group feed. In later PR, I will implement features for fetching posts from the Facebook API and cache to display comments for a particular post, as well as making the post show up on the tableview in the post details.

Milestones
This feature begins the implementation of the Stretch feature, “Comment on posts by mapping answers to post-id by posting them in the same Facebook post with delimiters”.

Test Plan
1. Run the simulator, then click the login button to login with Facebook credentials.
2. Once the feed appears, click on any post.
3. The user should see the corresponding details of the post.
4. Tap on the blue “Answer this Question” button.
5. Type anything on the “Write something…” textview, then tap the Respond button.
6. Go to the Facebook Group that this app is connected to, and notice that the comment appears on the Group feed with the id for the post it belongs to

Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/180898733-701eebff-cb2d-4225-a9ee-609764864993.mov
