### PR TITLE
Added pinch to resize on details

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -251,6 +251,10 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="bRU-Qa-uYY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <gestureRecognizers/>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="kLQ-kW-MZB" appends="YES" id="tM7-2B-Hn8"/>
+                        </connections>
                     </view>
                     <navigationItem key="navigationItem" id="Czr-1w-inP"/>
                     <connections>
@@ -263,6 +267,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="M70-2L-cLp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <pinchGestureRecognizer id="kLQ-kW-MZB">
+                    <connections>
+                        <action selector="pinchToZoom:" destination="X95-fU-b2f" id="NIg-mx-CTu"/>
+                    </connections>
+                </pinchGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-1249.2753623188407" y="1674.7767857142856"/>
         </scene>

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -24,6 +24,21 @@
     self.descriptionLabel.text = self.postInfo.textContent;
 }
 
+- (IBAction)pinchToZoom:(UIPinchGestureRecognizer*)sender {
+    if ([sender state] == UIGestureRecognizerStateBegan) {
+        NSLog(@"Began");
+    }
+    if ([sender state] == UIGestureRecognizerStateChanged) {
+        NSLog(@"%f", [sender scale]);
+        CGFloat originalSize = self.descriptionLabel.font.pointSize;
+        if (originalSize < 32 && [sender velocity] > 0) {
+            [self.descriptionLabel setFont:[UIFont systemFontOfSize:self.descriptionLabel.font.pointSize + 1]];
+        } else if (originalSize > 17 && [sender velocity] < 0) {
+            [self.descriptionLabel setFont:[UIFont systemFontOfSize:self.descriptionLabel.font.pointSize - 1]];
+        }
+    }
+}
+
 
 #pragma mark - Navigation
 

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -25,9 +25,6 @@
 }
 
 - (IBAction)pinchToZoom:(UIPinchGestureRecognizer*)sender {
-    if ([sender state] == UIGestureRecognizerStateBegan) {
-        NSLog(@"Began");
-    }
     if ([sender state] == UIGestureRecognizerStateChanged) {
         NSLog(@"%f", [sender scale]);
         CGFloat originalSize = self.descriptionLabel.font.pointSize;


### PR DESCRIPTION
### Description
This PR implements a pinch gesture on the details view, which allows the user to resize the question text for greater accessibility. The text size will never increase above 32 or decrease below 17. 

### Milestones
This feature completes the “Gesture” requirement, an MVP feature (Readme to be updated soon).

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/181438727-bc0a5ef0-bfea-445a-87ca-9bf3e3ee7849.mov

