### PR TITLE
Search view

### DIFF
--- a/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		BE05CF3628820F4400899BE9 /* CourseCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BE05CF3528820F4400899BE9 /* CourseCell.m */; };
 		BE166FE9289254C70062D0CF /* APIManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BE166FE8289254C70062D0CF /* APIManager.m */; };
 		BE166FEF289307240062D0CF /* CommentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BE166FEE289307240062D0CF /* CommentCell.m */; };
+		BE166FF22894855D0062D0CF /* SearchPostsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE166FF12894855D0062D0CF /* SearchPostsViewController.m */; };
 		BE1762E3287BDE0300B7DD03 /* ComposeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1762E2287BDE0300B7DD03 /* ComposeViewController.m */; };
 		BE53E1272888AD3000744F3A /* PostDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE53E1262888AD3000744F3A /* PostDetailsViewController.m */; };
 		BE53E12A2888AD6C00744F3A /* AnsweringViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE53E1292888AD6C00744F3A /* AnsweringViewController.m */; };
@@ -70,6 +71,8 @@
 		BE166FE8289254C70062D0CF /* APIManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APIManager.m; sourceTree = "<group>"; };
 		BE166FED289307240062D0CF /* CommentCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CommentCell.h; sourceTree = "<group>"; };
 		BE166FEE289307240062D0CF /* CommentCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CommentCell.m; sourceTree = "<group>"; };
+		BE166FF02894855D0062D0CF /* SearchPostsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SearchPostsViewController.h; sourceTree = "<group>"; };
+		BE166FF12894855D0062D0CF /* SearchPostsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SearchPostsViewController.m; sourceTree = "<group>"; };
 		BE1762E1287BDE0300B7DD03 /* ComposeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ComposeViewController.h; sourceTree = "<group>"; };
 		BE1762E2287BDE0300B7DD03 /* ComposeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ComposeViewController.m; sourceTree = "<group>"; };
 		BE53E1252888AD3000744F3A /* PostDetailsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostDetailsViewController.h; sourceTree = "<group>"; };
@@ -211,6 +214,8 @@
 				BE53E1262888AD3000744F3A /* PostDetailsViewController.m */,
 				BE53E1282888AD6C00744F3A /* AnsweringViewController.h */,
 				BE53E1292888AD6C00744F3A /* AnsweringViewController.m */,
+				BE166FF02894855D0062D0CF /* SearchPostsViewController.h */,
+				BE166FF12894855D0062D0CF /* SearchPostsViewController.m */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -541,6 +546,7 @@
 				BE05CF3628820F4400899BE9 /* CourseCell.m in Sources */,
 				BEA4666E2878CF2500D57C23 /* QuestionFeedViewController.m in Sources */,
 				BEA4666B28781C1F00D57C23 /* FBLoginViewController.m in Sources */,
+				BE166FF22894855D0062D0CF /* SearchPostsViewController.m in Sources */,
 				BE05CF3328820E1500899BE9 /* SelectCourseViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -477,7 +477,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ak7-xR-3ma" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4924.6376811594209" y="872.54464285714278"/>
+            <point key="canvasLocation" x="7130" y="873"/>
         </scene>
         <!--Select a Course-->
         <scene sceneID="EUZ-k0-GgN">
@@ -547,6 +547,77 @@
             </objects>
             <point key="canvasLocation" x="2793" y="873"/>
         </scene>
+        <!--Search Recent History-->
+        <scene sceneID="wO1-tf-LAY">
+            <objects>
+                <viewController id="S2i-p9-Ogb" customClass="SearchPostsViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="eNa-wt-I0o">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="xXY-kr-knt">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <searchBar key="tableHeaderView" contentMode="redraw" text="" placeholder="Search for posts by keyword" id="2BS-w5-uR9">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                    <textInputTraits key="textInputTraits"/>
+                                </searchBar>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="151" id="iEQ-R6-gvm">
+                                        <rect key="frame" x="0.0" y="88.5" width="414" height="151"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iEQ-R6-gvm" id="BAl-gm-9f6">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="151"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VWw-9p-ihO">
+                                                    <rect key="frame" x="25" y="25" width="363" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mz6-Rb-3RF">
+                                                    <rect key="frame" x="25" y="63" width="363" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Course" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XxF-La-cfF">
+                                                    <rect key="frame" x="25" y="105" width="127" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Viewed 2h ago " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cnc-yU-Aga">
+                                                    <rect key="frame" x="228" y="105" width="160" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="systemPinkColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="18t-my-UA0"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Search Recent History" id="WoV-Rr-g9F"/>
+                    <connections>
+                        <outlet property="searchBar" destination="2BS-w5-uR9" id="9d6-EK-Gq6"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="97I-nm-Mqk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4931.884057971015" y="872.54464285714278"/>
+        </scene>
         <!--Item-->
         <scene sceneID="VKf-ez-h8X">
             <objects>
@@ -580,7 +651,8 @@
                     <connections>
                         <segue destination="Wmf-FK-I7H" kind="relationship" relationship="viewControllers" destinationCreationSelector="homeSegue" id="VgY-0I-MZR"/>
                         <segue destination="21P-Wm-ohf" kind="relationship" relationship="viewControllers" destinationCreationSelector="testSegue" id="fAh-Ep-fpQ"/>
-                        <segue destination="75U-3j-Yod" kind="relationship" relationship="viewControllers" id="oCH-as-Dbh"/>
+                        <segue destination="w0K-Uj-DuY" kind="relationship" relationship="viewControllers" id="nAK-IS-e9s"/>
+                        <segue destination="75U-3j-Yod" kind="relationship" relationship="viewControllers" id="Y6e-Qf-7FX"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ArM-CH-OJ7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -659,7 +731,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eHX-oG-B08" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4004" y="873"/>
+            <point key="canvasLocation" x="6236" y="873"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="x7s-fA-SQj">
@@ -679,6 +751,25 @@
             </objects>
             <point key="canvasLocation" x="-297" y="1675"/>
         </scene>
+        <!--Item-->
+        <scene sceneID="doc-xa-xCG">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="w0K-Uj-DuY" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="sPT-R3-Sg1"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="OqU-e3-maN">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="S2i-p9-Ogb" kind="relationship" relationship="rootViewController" id="li9-cJ-j8T"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="88R-Kb-hso" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4035" y="873"/>
+        </scene>
     </scenes>
     <resources>
         <image name="person.fill" catalog="system" width="128" height="120"/>
@@ -696,6 +787,9 @@
         </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/CapstoneProject/View Controllers/FBLoginViewController.m
+++ b/CapstoneProject/View Controllers/FBLoginViewController.m
@@ -59,8 +59,9 @@
     
     NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
     NSString *course_id = [saved stringForKey:@"currentCourse"];
+    NSString *course_id_abbr = [saved stringForKey:@"currentCourseAbbr"];
     
-    if (!course_id) {
+    if (!course_id || !course_id_abbr) {
         [rootViewController setSelectedIndex:1];
     }
 }

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -9,6 +9,8 @@
 #import "AnsweringViewController.h"
 #import "CommentCell.h"
 #import "Post.h"
+#import "Parse/Parse.h"
+#import "FBSDKCoreKit/FBSDKCoreKit.h"
 
 @interface PostDetailsViewController () <AnsweringViewControllerDelegate, UITableViewDelegate, UITableViewDataSource>
 
@@ -30,6 +32,29 @@
     self.nameLabel.text = self.postInfo.user_name;
     self.dateLabel.text = self.postInfo.post_date_detailed;
     self.descriptionLabel.text = self.postInfo.textContent;
+    
+    NSString *current_user_id = [NSString stringWithFormat:@"%@%@", @"user", [FBSDKAccessToken currentAccessToken].userID];
+    
+    PFObject *postInParse = [[PFObject alloc] initWithClassName:current_user_id];
+    postInParse[@"post_id"] = self.postInfo.post_id;
+    postInParse[@"user_id"] = self.postInfo.user_id;
+    postInParse[@"user_name"] = self.postInfo.user_name;
+    postInParse[@"title"] = self.postInfo.titleContent;
+    postInParse[@"message"] = self.postInfo.textContent;
+    postInParse[@"course"] = self.postInfo.courses;
+    postInParse[@"read_date"] = [NSDate date];
+    
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    NSString *course_abbr = [saved stringForKey:@"currentCourseAbbr"];
+    postInParse[@"course"] = course_abbr;
+    
+    [postInParse saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+        if (succeeded) {
+            NSLog(@"Object saved!");
+        } else {
+            NSLog(@"Error: %@", error.description);
+        }
+    }];
     
     [self fetchComments];
 }

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -1,0 +1,16 @@
+//
+//  SearchPostsViewController.h
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 7/29/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SearchPostsViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -1,0 +1,39 @@
+//
+//  SearchPostsViewController.m
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 7/29/22.
+//
+
+#import "SearchPostsViewController.h"
+#import "FBSDKCoreKit/FBSDKCoreKit.h"
+
+@interface SearchPostsViewController ()
+
+@property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
+
+
+@end
+
+@implementation SearchPostsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    NSString *current_user_id = [FBSDKAccessToken currentAccessToken].userID;
+    NSString *userInParse = [NSString stringWithFormat:@"%@%@", @"user", current_user_id];
+    
+    
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+@end

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -7,11 +7,11 @@
 
 #import "SearchPostsViewController.h"
 #import "FBSDKCoreKit/FBSDKCoreKit.h"
+#import "Parse/Parse.h"
 
 @interface SearchPostsViewController ()
 
 @property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
-
 
 @end
 
@@ -19,21 +19,23 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
+    [self fetchPostsViewed];
+}
+
+- (void)fetchPostsViewed {
     NSString *current_user_id = [FBSDKAccessToken currentAccessToken].userID;
     NSString *userInParse = [NSString stringWithFormat:@"%@%@", @"user", current_user_id];
     
-    
-}
+    PFQuery *query = [PFQuery queryWithClassName:userInParse];
+    query.limit = 20;
 
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
+    [query findObjectsInBackgroundWithBlock:^(NSArray *posts, NSError *error) {
+        if (posts != nil) {
+            NSLog(@"Posts viewed: %@", posts);
+        } else {
+            NSLog(@"%@", error.localizedDescription);
+        }
+    }];
 }
-*/
 
 @end

--- a/CapstoneProject/View Controllers/SelectCourseViewController.m
+++ b/CapstoneProject/View Controllers/SelectCourseViewController.m
@@ -67,8 +67,10 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString *objectId = ((PFObject *) self.courseArray[indexPath.row]).objectId;
+    NSString *courseAbbr = ((PFObject *) self.courseArray[indexPath.row])[@"course_abbr"];
     NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
     [saved setObject:objectId forKey:@"currentCourse"];
+    [saved setObject:courseAbbr forKey:@"currentCourseAbbr"];
     
     UIView * fromView = self.tabBarController.selectedViewController.view;
     UIView * toView = self.tabBarController.viewControllers[0].view;


### PR DESCRIPTION
### Description
This PR implements saving post data to a Parse database and getting the data from the database. Whenever the user clicks on a post to view its details, the post that the user viewed is stored in Parse as an object with a name that contains its user-id (e.g. for a user with user-id = 12345, the post will be stored as an object called "user12345”). If the post has been viewed by the user before, the times_viewed field of the object will be incremented by 1.
This PR also implements the UI for the post search view.


### Milestones
This feature starts the “Search through already-read posts using a search bar” MVP feature, or Technically Ambiguous Problem 2. This feature is listed on PR #29.


### Test Plan
Here is a screen recording for this PR.
Notice that viewing a post for the first time adds an object to Parse, and viewing an already viewed post increments the times_viewed field in the corresponding Parse object but also creates a new object despite the increased view count. In the future, I would like to make sure to preventing the creation of a new object or remove the previous one.


https://user-images.githubusercontent.com/107252243/182003903-5df2c5dc-2178-46e1-bdde-e465daaa0213.mp4

