### PR TITLE
Search for posts

### DIFF
--- a/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		BE166FE9289254C70062D0CF /* APIManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BE166FE8289254C70062D0CF /* APIManager.m */; };
 		BE166FEF289307240062D0CF /* CommentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BE166FEE289307240062D0CF /* CommentCell.m */; };
 		BE166FF22894855D0062D0CF /* SearchPostsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE166FF12894855D0062D0CF /* SearchPostsViewController.m */; };
+		BE166FFE28986EDA0062D0CF /* SearchPostCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BE166FFD28986EDA0062D0CF /* SearchPostCell.m */; };
 		BE1762E3287BDE0300B7DD03 /* ComposeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1762E2287BDE0300B7DD03 /* ComposeViewController.m */; };
 		BE53E1272888AD3000744F3A /* PostDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE53E1262888AD3000744F3A /* PostDetailsViewController.m */; };
 		BE53E12A2888AD6C00744F3A /* AnsweringViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE53E1292888AD6C00744F3A /* AnsweringViewController.m */; };
@@ -73,6 +74,8 @@
 		BE166FEE289307240062D0CF /* CommentCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CommentCell.m; sourceTree = "<group>"; };
 		BE166FF02894855D0062D0CF /* SearchPostsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SearchPostsViewController.h; sourceTree = "<group>"; };
 		BE166FF12894855D0062D0CF /* SearchPostsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SearchPostsViewController.m; sourceTree = "<group>"; };
+		BE166FFC28986EDA0062D0CF /* SearchPostCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SearchPostCell.h; sourceTree = "<group>"; };
+		BE166FFD28986EDA0062D0CF /* SearchPostCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SearchPostCell.m; sourceTree = "<group>"; };
 		BE1762E1287BDE0300B7DD03 /* ComposeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ComposeViewController.h; sourceTree = "<group>"; };
 		BE1762E2287BDE0300B7DD03 /* ComposeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ComposeViewController.m; sourceTree = "<group>"; };
 		BE53E1252888AD3000744F3A /* PostDetailsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostDetailsViewController.h; sourceTree = "<group>"; };
@@ -182,6 +185,8 @@
 				BE05CF3528820F4400899BE9 /* CourseCell.m */,
 				BE166FED289307240062D0CF /* CommentCell.h */,
 				BE166FEE289307240062D0CF /* CommentCell.m */,
+				BE166FFC28986EDA0062D0CF /* SearchPostCell.h */,
+				BE166FFD28986EDA0062D0CF /* SearchPostCell.m */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -541,6 +546,7 @@
 				BEDF11602874FA0A00B080A4 /* main.m in Sources */,
 				BE8277D7287C8DDD0059B509 /* PostCell.m in Sources */,
 				BE8277DB287C91230059B509 /* Post.m in Sources */,
+				BE166FFE28986EDA0062D0CF /* SearchPostCell.m in Sources */,
 				BEDF11522874FA0A00B080A4 /* SceneDelegate.m in Sources */,
 				BE1762E3287BDE0300B7DD03 /* ComposeViewController.m in Sources */,
 				BE05CF3628820F4400899BE9 /* CourseCell.m in Sources */,

--- a/CapstoneProject.xcodeproj/xcuserdata/emilyokabe.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/CapstoneProject.xcodeproj/xcuserdata/emilyokabe.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>CapstoneProject.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>11</integer>
+			<integer>12</integer>
 		</dict>
 	</dict>
 </dict>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -555,9 +555,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="xXY-kr-knt">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="xXY-kr-knt">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <searchBar key="tableHeaderView" contentMode="redraw" id="av8-r1-NkD">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -572,35 +571,51 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="151"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VWw-9p-ihO">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VWw-9p-ihO">
                                                     <rect key="frame" x="25" y="25" width="363" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="21" id="Tyk-vF-XJJ"/>
+                                                    </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mz6-Rb-3RF">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mz6-Rb-3RF">
                                                     <rect key="frame" x="25" y="63" width="363" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Course" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XxF-La-cfF">
-                                                    <rect key="frame" x="25" y="105" width="127" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Course" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XxF-La-cfF">
+                                                    <rect key="frame" x="25" y="105" width="170" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Viewed 2h ago " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cnc-yU-Aga">
-                                                    <rect key="frame" x="228" y="105" width="160" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Viewed 2h ago " textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cnc-yU-Aga">
+                                                    <rect key="frame" x="271" y="105" width="117" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemPinkColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Mz6-Rb-3RF" firstAttribute="top" secondItem="VWw-9p-ihO" secondAttribute="bottom" constant="17" id="Bek-Rz-k0u"/>
+                                                <constraint firstItem="XxF-La-cfF" firstAttribute="top" secondItem="Mz6-Rb-3RF" secondAttribute="bottom" constant="21" id="DT1-JF-iCZ"/>
+                                                <constraint firstItem="VWw-9p-ihO" firstAttribute="top" secondItem="BAl-gm-9f6" secondAttribute="top" constant="25" id="Qes-c8-yL0"/>
+                                                <constraint firstItem="Mz6-Rb-3RF" firstAttribute="leading" secondItem="VWw-9p-ihO" secondAttribute="leading" id="Qsf-cP-odl"/>
+                                                <constraint firstItem="Mz6-Rb-3RF" firstAttribute="trailing" secondItem="VWw-9p-ihO" secondAttribute="trailing" id="Rsh-hf-v6q"/>
+                                                <constraint firstItem="VWw-9p-ihO" firstAttribute="leading" secondItem="BAl-gm-9f6" secondAttribute="leading" constant="25" id="St4-OD-3RF"/>
+                                                <constraint firstItem="cnc-yU-Aga" firstAttribute="top" secondItem="XxF-La-cfF" secondAttribute="top" id="TMk-Mf-2va"/>
+                                                <constraint firstItem="VWw-9p-ihO" firstAttribute="trailing" secondItem="cnc-yU-Aga" secondAttribute="trailing" id="X0m-M0-ykn"/>
+                                                <constraint firstItem="cnc-yU-Aga" firstAttribute="bottom" secondItem="XxF-La-cfF" secondAttribute="bottom" id="bPF-cI-KjD"/>
+                                                <constraint firstItem="cnc-yU-Aga" firstAttribute="leading" secondItem="XxF-La-cfF" secondAttribute="trailing" constant="76" id="bYx-vg-Ghc"/>
+                                                <constraint firstItem="XxF-La-cfF" firstAttribute="leading" secondItem="Mz6-Rb-3RF" secondAttribute="leading" id="crt-s3-0dv"/>
+                                                <constraint firstAttribute="trailing" secondItem="VWw-9p-ihO" secondAttribute="trailing" constant="26" id="eB4-S5-r1u"/>
+                                                <constraint firstItem="cnc-yU-Aga" firstAttribute="trailing" secondItem="Mz6-Rb-3RF" secondAttribute="trailing" id="pJk-UB-lCW"/>
+                                                <constraint firstAttribute="bottom" secondItem="XxF-La-cfF" secondAttribute="bottom" constant="25" id="pwM-gL-8du"/>
+                                                <constraint firstItem="Mz6-Rb-3RF" firstAttribute="trailing" secondItem="cnc-yU-Aga" secondAttribute="trailing" id="zlg-go-L50"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="bodyText" destination="Mz6-Rb-3RF" id="75u-aw-Jtz"/>
@@ -614,6 +629,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="18t-my-UA0"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="xXY-kr-knt" firstAttribute="leading" secondItem="18t-my-UA0" secondAttribute="leading" id="3Lu-te-Mz9"/>
+                            <constraint firstItem="18t-my-UA0" firstAttribute="trailing" secondItem="xXY-kr-knt" secondAttribute="trailing" id="O9i-36-x1e"/>
+                            <constraint firstItem="xXY-kr-knt" firstAttribute="bottom" secondItem="18t-my-UA0" secondAttribute="bottom" constant="83" id="iVU-5x-yEN"/>
+                            <constraint firstItem="18t-my-UA0" firstAttribute="top" secondItem="xXY-kr-knt" secondAttribute="top" constant="88" id="v0J-Px-CYy"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Search Recent History" id="WoV-Rr-g9F"/>
                     <connections>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -565,7 +565,7 @@
                                     <textInputTraits key="textInputTraits"/>
                                 </searchBar>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="151" id="iEQ-R6-gvm">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="151" id="iEQ-R6-gvm" customClass="SearchPostCell">
                                         <rect key="frame" x="0.0" y="88.5" width="414" height="151"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iEQ-R6-gvm" id="BAl-gm-9f6">
@@ -602,6 +602,12 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="bodyText" destination="Mz6-Rb-3RF" id="75u-aw-Jtz"/>
+                                            <outlet property="courseLabel" destination="XxF-La-cfF" id="BTQ-5G-Uro"/>
+                                            <outlet property="titleLabel" destination="VWw-9p-ihO" id="cQc-Xw-PEJ"/>
+                                            <outlet property="viewTimeLabel" destination="cnc-yU-Aga" id="6bs-DF-LPf"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -559,13 +559,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <searchBar key="tableHeaderView" contentMode="redraw" text="" placeholder="Search for posts by keyword" id="2BS-w5-uR9">
+                                <searchBar key="tableHeaderView" contentMode="redraw" id="av8-r1-NkD">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                     <textInputTraits key="textInputTraits"/>
                                 </searchBar>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="151" id="iEQ-R6-gvm" customClass="SearchPostCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchPostCell" rowHeight="151" id="iEQ-R6-gvm" customClass="SearchPostCell">
                                         <rect key="frame" x="0.0" y="88.5" width="414" height="151"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iEQ-R6-gvm" id="BAl-gm-9f6">
@@ -617,7 +617,8 @@
                     </view>
                     <navigationItem key="navigationItem" title="Search Recent History" id="WoV-Rr-g9F"/>
                     <connections>
-                        <outlet property="searchBar" destination="2BS-w5-uR9" id="9d6-EK-Gq6"/>
+                        <outlet property="searchBar" destination="av8-r1-NkD" id="64a-yt-miq"/>
+                        <outlet property="tableView" destination="xXY-kr-knt" id="TEJ-1S-2v3"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="97I-nm-Mqk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -50,6 +50,8 @@
                     [object incrementKey:@"times_viewed"];
                     [object saveInBackground];
                     return;
+                } else if (error == nil) {
+                    NSLog(@"Error: No matching object found");
                 } else {
                     NSLog(@"Error: %@", error.description);
                 }

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -11,6 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SearchPostsViewController : UIViewController
 
+@property (nonatomic, strong) NSMutableArray *postArray;
+@property (nonatomic, strong) NSMutableArray *filteredPostArray;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -97,6 +97,8 @@
     self.searchBar.showsCancelButton = NO;
     self.searchBar.text = @"";
     [self.searchBar resignFirstResponder];
+    self.filteredPostArray = self.postArray;
+    [self.tableView reloadData];
 }
 
 @end

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -24,6 +24,7 @@
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.searchBar.delegate = self;
+    self.postArray = [[NSMutableArray alloc] init];
     self.filteredPostArray = [[NSMutableArray alloc] init];
     [self fetchPostsViewed];
 }
@@ -31,7 +32,8 @@
 - (void)fetchPostsViewed {
     [self getPostsViewedWithCompletion:^(NSArray *result, NSError *error) {
         if ([result count] != 0) {
-            self.filteredPostArray = [NSMutableArray arrayWithArray:result];
+            self.postArray = [NSMutableArray arrayWithArray:result];
+            self.filteredPostArray = self.postArray;
             [self.tableView reloadData];
         } else if (!error) {
             // no courses viewed
@@ -71,6 +73,30 @@
     [cell setSearchPostCell:self.filteredPostArray[indexPath.row]];
     
     return cell;
+}
+
+- (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {
+    self.searchBar.showsCancelButton = YES;
+}
+
+- (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText {
+    if (searchText.length != 0) {
+        
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"message CONTAINS[cd] %@", searchText];
+        self.filteredPostArray = [NSMutableArray arrayWithArray:[self.postArray filteredArrayUsingPredicate:predicate]];
+        [self.tableView reloadData];
+    }
+    else {
+        self.filteredPostArray = self.postArray;
+    }
+    
+    [self.tableView reloadData];
+}
+
+- (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar {
+    self.searchBar.showsCancelButton = NO;
+    self.searchBar.text = @"";
+    [self.searchBar resignFirstResponder];
 }
 
 @end

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -8,9 +8,11 @@
 #import "SearchPostsViewController.h"
 #import "FBSDKCoreKit/FBSDKCoreKit.h"
 #import "Parse/Parse.h"
+#import "SearchPostCell.h"
 
-@interface SearchPostsViewController ()
+@interface SearchPostsViewController () <UITableViewDelegate, UITableViewDataSource, UISearchBarDelegate>
 
+@property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
 
 @end
@@ -19,10 +21,28 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.tableView.delegate = self;
+    self.tableView.dataSource = self;
+    self.searchBar.delegate = self;
+    self.filteredPostArray = [[NSMutableArray alloc] init];
     [self fetchPostsViewed];
 }
 
 - (void)fetchPostsViewed {
+    [self getPostsViewedWithCompletion:^(NSArray *result, NSError *error) {
+        if ([result count] != 0) {
+            self.filteredPostArray = [NSMutableArray arrayWithArray:result];
+            [self.tableView reloadData];
+        } else if (!error) {
+            // no courses viewed
+            NSLog(@"No courses viewed yet!");
+        } else {
+            NSLog(@"Error: %@", error.localizedDescription);
+        }
+    }];
+}
+
+- (void)getPostsViewedWithCompletion:(void(^)(NSArray *posts, NSError *error))completion {
     NSString *current_user_id = [FBSDKAccessToken currentAccessToken].userID;
     NSString *userInParse = [NSString stringWithFormat:@"%@%@", @"user", current_user_id];
     
@@ -32,10 +52,25 @@
     [query findObjectsInBackgroundWithBlock:^(NSArray *posts, NSError *error) {
         if (posts != nil) {
             NSLog(@"Posts viewed: %@", posts);
+            completion(posts, nil);
         } else {
             NSLog(@"%@", error.localizedDescription);
+            completion(nil, error);
         }
     }];
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.filteredPostArray.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    
+    SearchPostCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"SearchPostCell"
+                                                                 forIndexPath:indexPath];
+    [cell setSearchPostCell:self.filteredPostArray[indexPath.row]];
+    
+    return cell;
 }
 
 @end

--- a/CapstoneProject/Views/SearchPostCell.h
+++ b/CapstoneProject/Views/SearchPostCell.h
@@ -1,0 +1,25 @@
+//
+//  SearchPostCell.h
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 8/1/22.
+//
+
+#import <UIKit/UIKit.h>
+#import "Parse/Parse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SearchPostCell : UITableViewCell
+
+@property (nonatomic, strong) PFObject *post;
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
+@property (weak, nonatomic) IBOutlet UILabel *bodyText;
+@property (weak, nonatomic) IBOutlet UILabel *courseLabel;
+@property (weak, nonatomic) IBOutlet UILabel *viewTimeLabel;
+
+- (void)setSearchPostCell:(PFObject *)post;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CapstoneProject/Views/SearchPostCell.m
+++ b/CapstoneProject/Views/SearchPostCell.m
@@ -18,8 +18,6 @@
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
 }
 
 - (void)setSearchPostCell:(PFObject *)post {
@@ -28,7 +26,7 @@
     self.titleLabel.text = post[@"title"];
     self.bodyText.text = post[@"message"];
     self.courseLabel.text = post[@"course"];
-    self.viewTimeLabel.text = ((NSDate *)post[@"read_date"]).shortTimeAgoSinceNow;
+    self.viewTimeLabel.text = [NSString stringWithFormat:@"%@%@%@", @"Viewed ", ((NSDate *)post[@"read_date"]).shortTimeAgoSinceNow, @" ago"];
 }
 
 @end

--- a/CapstoneProject/Views/SearchPostCell.m
+++ b/CapstoneProject/Views/SearchPostCell.m
@@ -1,0 +1,32 @@
+//
+//  SearchPostCell.m
+//  CapstoneProject
+//
+//  Created by Emily Ito Okabe on 8/1/22.
+//
+
+#import "SearchPostCell.h"
+
+@implementation SearchPostCell
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+- (void)setSearchPostCell:(PFObject *)post {
+    _post = post;
+    
+    self.titleLabel.text = post[@"title"];
+    self.bodyText.text = post[@"message"];
+    self.courseLabel.text = post[@"course"];
+    self.viewTimeLabel.text = post[@"read_date"];
+}
+
+@end

--- a/CapstoneProject/Views/SearchPostCell.m
+++ b/CapstoneProject/Views/SearchPostCell.m
@@ -6,6 +6,8 @@
 //
 
 #import "SearchPostCell.h"
+#import "DateTools.h"
+#import "NSDate+DateTools.h"
 
 @implementation SearchPostCell
 
@@ -26,7 +28,7 @@
     self.titleLabel.text = post[@"title"];
     self.bodyText.text = post[@"message"];
     self.courseLabel.text = post[@"course"];
-    self.viewTimeLabel.text = post[@"read_date"];
+    self.viewTimeLabel.text = ((NSDate *)post[@"read_date"]).shortTimeAgoSinceNow;
 }
 
 @end


### PR DESCRIPTION
### Description
This PR builds off of #28, which implements getting the courses that the user viewed from Parse. This PR displays these courses as a TableView and implements search filtering, where typing text into the search bar automatically filters out posts that don't include this text. A cancel button appears whenever the search bar is clicked, and pressing the cancel button makes the cancel button disappear and the table of posts to display all viewed posts again. 
I have yet to implement a prioritized version of the post table, such that posts that are viewed more often or more recently are placed toward the top. I also need to implement clicking on a post to go to its details view.

### Milestones
The milestone implemented is the “Search through already-read posts using a search bar” MVP feature, or Technically Ambiguous Problem 2.

### Test Plan
First, log into the app using Facebook credentials (unless you are automatically logged in). Then, follow the demo video below:

https://user-images.githubusercontent.com/107252243/182263795-b2174528-3e5e-4aee-953b-4e4b034fe7ba.mov

