### PR TITLE
Infinite scroll

### DIFF
--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSCache *postCache;
 
+- (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -6,6 +6,8 @@
 //
 
 #import "APIManager.h"
+#import "FBSDKCoreKit/FBSDKCoreKit.h"
+#import "Post.h"
 
 @implementation APIManager
 
@@ -15,6 +17,48 @@
         self.postCache = [[NSCache alloc] init];
     }
     return self;
+}
+
+- (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion {
+    
+    NSString *untilDateStr = until;
+    NSString *sinceDateStr = since;
+    
+    if (untilDateStr == nil) {
+        untilDateStr = @"now";
+    }
+    
+    if (sinceDateStr == nil) {   // set 'since' to two weeks before until
+        double daysinInterval = 2;  // number of days into the past to get posts up to
+        NSTimeInterval twoWeekInterval = (NSTimeInterval)(daysinInterval * -86400);
+        
+        NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+        [dateFormat setDateFormat:@"yyyy-MM-dd"];
+        
+        NSDate *startDate = [NSDate dateWithTimeInterval:twoWeekInterval sinceDate:[dateFormat dateFromString:untilDateStr]];
+        
+        sinceDateStr = [dateFormat stringFromDate:startDate];
+    }
+    
+    NSLog(@"untilDateStr = %@", untilDateStr);
+    NSLog(@"sinceDateStr = %@", sinceDateStr);
+    
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+                                  initWithGraphPath:@"/425184976239857/feed"
+                                  parameters:@{ @"fields": @"from,created_time,message",@"until": untilDateStr,@"since": sinceDateStr}
+                                  HTTPMethod:@"GET"];
+    
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        if (!error) {
+            NSMutableArray *posts = [Post postsWithArray:result[@"data"]];
+            NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+            [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
+            
+            completion(posts, [dateFormat stringFromDate:((Post *)[posts lastObject]).post_date], nil);
+        } else {
+            completion(nil, nil, error);
+        }
+    }];
 }
 
 @end

--- a/CapstoneProject/Info.plist
+++ b/CapstoneProject/Info.plist
@@ -43,9 +43,9 @@
 			</array>
 		</dict>
 	</dict>
-    <key>FacebookAutoLogAppEventsEnabled</key>
-    <string>TRUE</string>
-    <key>FacebookAdvertiserIDCollectionEnabled</key>
-    <string>TRUE</string>
+	<key>FacebookAutoLogAppEventsEnabled</key>
+	<string>TRUE</string>
+	<key>FacebookAdvertiserIDCollectionEnabled</key>
+	<string>TRUE</string>
 </dict>
 </plist>

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -86,6 +86,27 @@
 
 - (void)fetchComments {
     NSMutableArray *posts = [self.apiManagerFromFeed.postCache objectForKey:@"posts"];
+    
+    NSDate *lastCachedDate = ((Post *)[posts lastObject]).post_date;
+    NSDate *thisPostDate = self.postInfo.post_date;
+    
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
+    
+    NSString *startDate = [dateFormat stringFromDate:thisPostDate];
+    NSString *endDate = [dateFormat stringFromDate:lastCachedDate];
+    
+    if ([thisPostDate compare:lastCachedDate] == NSOrderedAscending) {   // Fetch more posts
+        [self.apiManagerFromFeed getNextSetOfPostsWithCompletion:endDate startDate:startDate completion:^(NSMutableArray * _Nonnull result, NSString * _Nonnull lastDate, NSError * _Nonnull error) {
+            [posts addObjectsFromArray:result];
+            [self addCommentsToArray:posts];
+        }];
+    } else {
+        [self addCommentsToArray:posts];
+    }
+}
+
+- (void)addCommentsToArray:(NSMutableArray *)posts {
     for (Post *post in posts) {
         if ([post.parent_post_id isEqualToString:self.postInfo.post_id]) {
             [self.commentArray addObject:post];

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.h
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableArray *postsToBeCached;
 
+@property (assign, nonatomic) BOOL isMoreDataLoading;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -34,10 +34,11 @@
     self.postArray = [[NSMutableArray alloc] init];
     self._apiManager = [[APIManager alloc] init];
     self.postsToBeCached = [[NSMutableArray alloc] init];
+    self.isMoreDataLoading = NO;
     
     // Initialize a UIRefreshControl
     self.refreshControl = [[UIRefreshControl alloc] init];
-    [self.refreshControl addTarget:self action:@selector(fetchPosts) forControlEvents:UIControlEventValueChanged];
+    [self.refreshControl addTarget:self action:@selector(fetchPosts:) forControlEvents:UIControlEventValueChanged];
     [self.tableView insertSubview:self.refreshControl atIndex:0];
 }
 
@@ -53,21 +54,29 @@
     self.view.window.rootViewController = loginViewController; // substitute, less elegant
 }
 
-- (void)fetchPosts {
+- (void)fetchPosts:(BOOL)isFirst{
     NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
     NSString *course_id = [saved stringForKey:@"currentCourse"];
     NSLog(@"course_id = %@", course_id);
     
-    [self.postArray removeAllObjects];
-    [self.postsToBeCached removeAllObjects];
-    [self fetchPostsRec:course_id endDate:nil startDate:nil];
+    if (isFirst) {
+        [self.postArray removeAllObjects];
+        [self.postsToBeCached removeAllObjects];
+    }
+    
+    [self fetchPostsRec:course_id endDate:nil startDate:nil numAdded:0 firstFetch:isFirst];
 }
 
-- (void)fetchPostsRec:(NSString *)course_id endDate:(NSString *)until startDate:(NSString *)since {
-    [self getNextSetOfPostsWithCompletion:until startDate:since completion:^(NSMutableArray *posts, NSString *lastDate, NSError *error) {
+- (void)fetchPostsRec:(NSString *)course_id endDate:(NSString *)until startDate:(NSString *)since numAdded:(NSInteger)count firstFetch:(BOOL)isFirst {
+    __block NSInteger numPosts = 0;
+    [self._apiManager getNextSetOfPostsWithCompletion:until startDate:since completion:^(NSMutableArray *posts, NSString *lastDate, NSError *error) {
         if (!error) {
             if ([posts count] == 0) {
-                [self._apiManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                if (isFirst) {
+                    [self._apiManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                }
+                
+                self.isMoreDataLoading = NO;
                 [self.tableView reloadData];
                 return;
             }
@@ -75,21 +84,26 @@
                 [self.postsToBeCached addObject:post];
                 if ([post.parent_post_id isEqualToString:@""] && [post.courses isEqualToString:course_id]) {
                     [self.postArray addObject:post];
+                    numPosts++;
                 }
             }
             NSLog(@"after for loop");
-            if ([self.postArray count] < 10) {
+            if (numPosts < 2) {  //[self.postArray count] - count
                 NSLog(@"count = %lu", (unsigned long)[self.postArray count]);
                 NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
                 [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
                 NSLog(@"Date = %@", [dateFormat stringFromDate:((Post *)[self.postArray lastObject]).post_date]);
-                [self fetchPostsRec:course_id endDate:lastDate startDate:nil];
+                [self fetchPostsRec:course_id endDate:lastDate startDate:nil numAdded:(count + numPosts) firstFetch:isFirst];
             } else {
                 __weak typeof(self) weakSelf = self;
                 dispatch_async(dispatch_get_main_queue(), ^{
                     __strong typeof(self) strongSelf = weakSelf;
                     if (strongSelf) {
-                        [self._apiManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                        if (isFirst) {
+                            [self._apiManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                        }
+                        
+                        self.isMoreDataLoading = NO;
                         [self.tableView reloadData];
                     }
                 });
@@ -100,65 +114,6 @@
         }
     }];
 }
-
-- (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion {
-    
-    NSString *untilDateStr = until;
-    NSString *sinceDateStr = since;
-    
-    if (untilDateStr == nil) {
-        untilDateStr = @"now";
-    }
-    
-    if (sinceDateStr == nil) {   // set 'since' to two weeks before until
-        double daysinInterval = 7;  // number of days into the past to get posts up to
-        NSTimeInterval twoWeekInterval = (NSTimeInterval)(daysinInterval * -86400);
-        
-        NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-        [dateFormat setDateFormat:@"yyyy-MM-dd"];
-        
-        NSDate *startDate = [NSDate dateWithTimeInterval:twoWeekInterval sinceDate:[dateFormat dateFromString:untilDateStr]];
-        
-        sinceDateStr = [dateFormat stringFromDate:startDate];
-    }
-    
-    NSLog(@"untilDateStr = %@", untilDateStr);
-    NSLog(@"sinceDateStr = %@", sinceDateStr);
-    
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-                                  initWithGraphPath:@"/425184976239857/feed"
-                                  parameters:@{ @"fields": @"from,created_time,message",@"until": untilDateStr,@"since": sinceDateStr}
-                                  HTTPMethod:@"GET"];
-    
-    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-        if (!error) {
-            NSMutableArray *posts = [Post postsWithArray:result[@"data"]];
-            NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-            [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
-            
-            completion(posts, [dateFormat stringFromDate:((Post *)[posts lastObject]).post_date], nil);
-        } else {
-            completion(nil, nil, error);
-        }
-    }];
-}
-
-- (void)getAllPostsWithCompletion:(void(^)(NSMutableArray *posts, NSError *error))completion {
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-                                  initWithGraphPath:@"/425184976239857/feed"
-                                  parameters:@{ @"fields": @"from, created_time, message"}
-                                  HTTPMethod:@"GET"];
-    
-    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-        if (!error) {
-            NSMutableArray *posts = [Post postsWithArray:result[@"data"]];
-            completion(posts, nil);
-        } else {
-            completion(nil, error);
-        }
-    }];
-}
-
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
     PostCell *cell = [tableView dequeueReusableCellWithIdentifier:@"PostCell"];
@@ -172,13 +127,49 @@
     return self.postArray.count;
 }
 
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView{
+    if(!self.isMoreDataLoading){
+        // Calculate the position of one screen length before the bottom of the results
+        int scrollViewContentHeight = self.tableView.contentSize.height;
+        int scrollOffsetThreshold = scrollViewContentHeight - self.tableView.bounds.size.height;
+        
+        // When the user has scrolled past the threshold, start requesting
+        if(scrollView.contentOffset.y > scrollOffsetThreshold && self.tableView.isDragging) {
+            self.isMoreDataLoading = true;
+            NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+            NSString *course_id = [saved stringForKey:@"currentCourse"];
+            
+            NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+            [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
+            NSString *dateStr = [dateFormat stringFromDate:((Post *)[self.postArray lastObject]).post_date];
+            [self fetchPostsRec:course_id endDate:dateStr startDate:nil numAdded:0 firstFetch:NO];
+        }
+    }
+}
+
+/*
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath{
+    if (indexPath.row + 1 == [self.postArray count]) {
+        NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+        NSString *course_id = [saved stringForKey:@"currentCourse"];
+        
+        NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+        [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
+        NSString *dateStr = [dateFormat stringFromDate:((Post *)self.postArray[indexPath.row]).post_date];
+        
+        [self fetchPostsRec:course_id endDate:dateStr startDate:nil originalCount:[self.postArray count] firstFetch:NO];
+    }
+}
+ */
+
 - (void)didPost:(nonnull Post *)post {
-    [self fetchPosts];
+    [self fetchPosts:YES];
     [self.tableView reloadData];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    [self fetchPosts];
+    NSLog(@"View will appear called!");
+    [self fetchPosts:YES];
     [self.tableView reloadData];
 }
 


### PR DESCRIPTION
### Description
This PR builds off of #23 (dynamically fetching posts), #25 (caching newest posts), and #27 (displaying comments). This current PR implements infinite scrolling, where, once the user scrolls all the way to the bottom of the post feed, more posts are loaded. Only the posts that were loaded during the first batch are cached.
For comments displayed in the details view, if the post selected is created after the beginning of the cached time frame, comments are filtered through only the cache. If the post selected is created before the beginning of the cached time frame, the posts between the post creation date and beginning of the cached time frame are fetched via the Facebook API and filtered.


### Milestones
This feature adds on to the “Cache posts”  and “Dynamically fetch posts by date range to prevent fetching too many posts at a time” features, which will count towards the “Technically Ambiguous Problem” requirement.


### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/182541748-4f2ee717-5090-4dae-a65f-bbdb0e563cc9.mp4

