### PR TITLE
Switch to details

### DIFF
--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSCache *postCache;
 
+- (void)getPostDictFromIDWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -6,6 +6,7 @@
 //
 
 #import "APIManager.h"
+#import "FBSDKCoreKit/FBSDKCoreKit.h"
 
 @implementation APIManager
 
@@ -15,6 +16,23 @@
         self.postCache = [[NSCache alloc] init];
     }
     return self;
+}
+
+
+- (void)getPostDictFromIDWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion {
+    
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+                                  initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
+                                  parameters:@{ @"fields": @"from,created_time,message"}
+                                  HTTPMethod:@"GET"];
+    
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        if (!error) {
+            completion(result, nil);
+        } else {
+            completion(nil, error);
+        }
+    }];
 }
 
 @end

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -174,7 +174,7 @@
         <!--Post Details View Controller-->
         <scene sceneID="OtQ-xi-EnW">
             <objects>
-                <viewController id="X95-fU-b2f" customClass="PostDetailsViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PostDetailsViewController" id="X95-fU-b2f" customClass="PostDetailsViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Quh-TJ-bpF">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -49,16 +49,21 @@
                     NSLog(@"Duplicate object: %@", object);
                     [object incrementKey:@"times_viewed"];
                     [object saveInBackground];
-                    return;
+                    [self fetchComments];
                 } else if (error == nil) {
                     NSLog(@"Error: No matching object found");
                 } else {
                     NSLog(@"Error: %@", error.description);
                 }
             }];
+        } else {
+            [self createNewReadPost:current_user_id];
+            [self fetchComments];
         }
     }];
+}
 
+- (void)createNewReadPost:(NSString *)current_user_id {
     PFObject *postInParse = [[PFObject alloc] initWithClassName:current_user_id];
     postInParse[@"post_id"] = self.postInfo.post_id;
     postInParse[@"user_id"] = self.postInfo.user_id;
@@ -80,8 +85,6 @@
             NSLog(@"Error: %@", error.description);
         }
     }];
-    
-    [self fetchComments];
 }
 
 - (void)fetchComments {

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -141,4 +141,5 @@
     return self.commentArray.count;
 }
 
+
 @end

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -6,6 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "APIManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableArray *postArray;
 @property (nonatomic, strong) NSMutableArray *filteredPostArray;
+
+@property (nonatomic, strong) APIManager *_apiManager;
 
 @end
 

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -93,8 +93,6 @@
     else {
         self.filteredPostArray = self.postArray;
     }
-    
-    [self.tableView reloadData];
 }
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar {

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -114,11 +114,9 @@
             
             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
             PostDetailsViewController *rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"PostDetailsViewController"];
-            
             Post *p = [[Post alloc] initWithDictionary:post];
             rootViewController.postInfo = p;
-            
-            self.view.window.rootViewController = rootViewController;
+            [self.navigationController pushViewController:rootViewController animated:YES];
             
         } else if (!error) {
             NSLog(@"Error: could not find post with matching id");

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -126,35 +126,5 @@
     }];
 }
 
-/*
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    NSIndexPath *indexPath = [self.tableView indexPathForCell:sender];
-    
-    if ([FBSDKAccessToken currentAccessToken] == nil) {
-        NSLog(@"No access token");
-    }
-    
-    if ([segue.identifier isEqualToString:@"searchToDetailsSegue"]) {
-        // 1 Get indexpath
-        NSString *post_id = self.filteredPostArray[indexPath.row][@"post_id"] ;
-        
-        FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-                                      initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
-                                      parameters:@{ @"fields": @"from, created_time, message"}
-                                      HTTPMethod:@"GET"];
-        
-        [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-            if (!error) {
-                NSLog(@"%@", result);
-                Post *post = [[Post alloc] initWithDictionary:result];
-                PostDetailsViewController *detailsVC = [segue destinationViewController];
-                detailsVC.postInfo = post;
-            } else {
-                NSLog(@"Error posting to feed: %@", error.localizedDescription);
-            }
-        }];
-    }
-}
- */
 
 @end


### PR DESCRIPTION
### Description
This PR builds off of PR #30, which implements typing a keyword into the search bar to search through posts. The current PR implements switching to the details view for the post whenever a post that appears in the search table is clicked. After switching to the details, the tab bar and a back button still show up so that the user can still navigate through the app.

One functionality that needs to be fixed is displaying the comments after switching from the search to the details view. I know that this occurs because the cache is not passed from the search to the details view, and will fix this soon.


### Milestones
This feature adds on to the “Search through already-read posts using a search bar” feature, which will count towards the “Technically Ambiguous Problem” requirement.


### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/182541897-447611fe-3b08-4e7e-9e3c-c4ce0f8b8e04.mov

