### PR TITLE
Jump to details comments

### DIFF
--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -11,6 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface APIManager : NSObject
 
+@property (class, strong, readonly) APIManager *sharedManager;
+
+@property (nonatomic, copy, nullable) NSString *myString;
+
 @property (nonatomic, strong) NSCache *postCache;
 
 - (void)getPostDictFromIDWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion;

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -19,6 +19,15 @@
     return self;
 }
 
++ (instancetype)sharedManager {
+    static id sharedMyManager = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedMyManager = [[self alloc] init];
+    });
+    return sharedMyManager;
+}
+
 - (void)getPostDictFromIDWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion {
     
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
@@ -45,7 +54,7 @@
     }
     
     if (sinceDateStr == nil) {   // set 'since' to two weeks before until
-        double daysinInterval = 2;  // number of days into the past to get posts up to
+        double daysinInterval = 3;  // number of days into the past to get posts up to
         NSTimeInterval twoWeekInterval = (NSTimeInterval)(daysinInterval * -86400);
         
         NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];

--- a/CapstoneProject/View Controllers/PostDetailsViewController.h
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.h
@@ -20,8 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UILabel *descriptionLabel;
 @property (weak, nonatomic) IBOutlet UIButton *answerButton;
 @property (strong, nonatomic) Post *postInfo;
-@property (nonatomic, strong) NSMutableArray *array;
-@property (nonatomic, strong) APIManager *apiManagerFromFeed;
+@property (nonatomic, strong) APIManager *sharedManager;
 @property (nonatomic, strong) NSMutableArray *commentArray;
 
 @end

--- a/CapstoneProject/View Controllers/PostDetailsViewController.h
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UILabel *descriptionLabel;
 @property (weak, nonatomic) IBOutlet UIButton *answerButton;
 @property (strong, nonatomic) Post *postInfo;
+@property (nonatomic, strong) NSMutableArray *array;
 @property (nonatomic, strong) APIManager *apiManagerFromFeed;
 @property (nonatomic, strong) NSMutableArray *commentArray;
 

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -88,7 +88,7 @@
 }
 
 - (void)fetchComments {
-    NSMutableArray *posts = self.array; //[self.apiManagerFromFeed.postCache objectForKey:@"posts"];
+    NSMutableArray *posts = [self.sharedManager.postCache objectForKey:@"posts"];
     
     NSDate *lastCachedDate = ((Post *)[posts lastObject]).post_date;
     NSDate *thisPostDate = self.postInfo.post_date;
@@ -100,7 +100,7 @@
     NSString *endDate = [dateFormat stringFromDate:lastCachedDate];
     
     if ([thisPostDate compare:lastCachedDate] == NSOrderedAscending) {   // Fetch more posts
-        [self.apiManagerFromFeed getNextSetOfPostsWithCompletion:endDate startDate:startDate completion:^(NSMutableArray * _Nonnull result, NSString * _Nonnull lastDate, NSError * _Nonnull error) {
+        [self.sharedManager getNextSetOfPostsWithCompletion:endDate startDate:startDate completion:^(NSMutableArray * _Nonnull result, NSString * _Nonnull lastDate, NSError * _Nonnull error) {
             [posts addObjectsFromArray:result];
             [self addCommentsToArray:posts];
         }];

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -88,7 +88,7 @@
 }
 
 - (void)fetchComments {
-    NSMutableArray *posts = [self.apiManagerFromFeed.postCache objectForKey:@"posts"];
+    NSMutableArray *posts = self.array; //[self.apiManagerFromFeed.postCache objectForKey:@"posts"];
     
     NSDate *lastCachedDate = ((Post *)[posts lastObject]).post_date;
     NSDate *thisPostDate = self.postInfo.post_date;

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.h
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) APIManager *_apiManager;
 
+//@property (nonatomic, strong) APIManager *sharedManager;
+
 @property (nonatomic, strong) NSMutableArray *postsToBeCached;
 
 @property (assign, nonatomic) BOOL isMoreDataLoading;

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.h
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.h
@@ -18,9 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableArray *postArray;
 
-@property (nonatomic, strong) APIManager *_apiManager;
-
-//@property (nonatomic, strong) APIManager *sharedManager;
+@property (nonatomic, strong) APIManager *sharedManager;
 
 @property (nonatomic, strong) NSMutableArray *postsToBeCached;
 

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -36,6 +36,8 @@
     self.postsToBeCached = [[NSMutableArray alloc] init];
     self.isMoreDataLoading = NO;
     
+    //self.sharedManager = [APIManager sharedManager];
+    
     // Initialize a UIRefreshControl
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(fetchPosts:) forControlEvents:UIControlEventValueChanged];
@@ -88,7 +90,7 @@
                 }
             }
 
-            if (numPosts < 2) {   // not enough posts displayed
+            if (numPosts < 10) {   // not enough posts displayed
                 NSLog(@"count = %lu", (unsigned long)[self.postArray count]);
                 NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
                 [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
@@ -101,6 +103,7 @@
                     if (strongSelf) {
                         if (isFirst) {
                             [self._apiManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                            //[self.sharedManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
                         }
                         self.isMoreDataLoading = NO;
                         [self.tableView reloadData];

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -32,11 +32,11 @@
     self.tableView.delegate = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     self.postArray = [[NSMutableArray alloc] init];
-    self._apiManager = [[APIManager alloc] init];
+    //self._apiManager = [[APIManager alloc] init];
     self.postsToBeCached = [[NSMutableArray alloc] init];
     self.isMoreDataLoading = NO;
     
-    //self.sharedManager = [APIManager sharedManager];
+    self.sharedManager = [APIManager sharedManager];
     
     // Initialize a UIRefreshControl
     self.refreshControl = [[UIRefreshControl alloc] init];
@@ -71,11 +71,11 @@
 
 - (void)fetchPostsRec:(NSString *)course_id endDate:(NSString *)until startDate:(NSString *)since numAdded:(NSInteger)count firstFetch:(BOOL)isFirst {
     __block NSInteger numPosts = 0;
-    [self._apiManager getNextSetOfPostsWithCompletion:until startDate:since completion:^(NSMutableArray *posts, NSString *lastDate, NSError *error) {
+    [self.sharedManager getNextSetOfPostsWithCompletion:until startDate:since completion:^(NSMutableArray *posts, NSString *lastDate, NSError *error) {
         if (!error) {
             if ([posts count] == 0) {   // no more posts left in Facebook Group: load posts to tableView
                 if (isFirst) {
-                    [self._apiManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                    [self.sharedManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
                 }
                 self.isMoreDataLoading = NO;
                 [self.tableView reloadData];
@@ -102,8 +102,7 @@
                     __strong typeof(self) strongSelf = weakSelf;
                     if (strongSelf) {
                         if (isFirst) {
-                            [self._apiManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
-                            //[self.sharedManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                            [self.sharedManager.postCache setObject:self.postsToBeCached forKey:@"posts"];
                         }
                         self.isMoreDataLoading = NO;
                         [self.tableView reloadData];
@@ -174,14 +173,14 @@
         
         // 2 Get post and API manager to pass
         Post *postToPass = self.postArray[indexPath.row];
-        APIManager *apiManagerToPass = self._apiManager;
+        APIManager *apiManagerToPass = self.sharedManager;
         
         // 3 Get reference to destination controller
         PostDetailsViewController *detailsVC = [segue destinationViewController];
         
         // 4 Pass the local dictionary to the view controller property
         detailsVC.postInfo = postToPass;
-        detailsVC.apiManagerFromFeed = apiManagerToPass;
+        detailsVC.sharedManager = apiManagerToPass;
     }
 }
 

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -32,7 +32,6 @@
     self.tableView.delegate = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     self.postArray = [[NSMutableArray alloc] init];
-    //self._apiManager = [[APIManager alloc] init];
     self.postsToBeCached = [[NSMutableArray alloc] init];
     self.isMoreDataLoading = NO;
     

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSMutableArray *postArray;
 @property (nonatomic, strong) NSMutableArray *filteredPostArray;
 
-@property (nonatomic, strong) APIManager *_apiManager;
+@property (nonatomic, strong) APIManager *sharedManager;
 
 @end
 

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -12,6 +12,7 @@
 #import "SearchPostCell.h"
 #import "Post.h"
 #import "PostDetailsViewController.h"
+#import "APIManager.h"
 
 @interface SearchPostsViewController () <UITableViewDelegate, UITableViewDataSource, UISearchBarDelegate>
 
@@ -28,8 +29,16 @@
     self.tableView.dataSource = self;
     self.searchBar.delegate = self;
     self.postArray = [[NSMutableArray alloc] init];
-    self._apiManager = [[APIManager alloc] init];
     self.filteredPostArray = [[NSMutableArray alloc] init];
+    
+    
+    //YourAppDelegateClass *appDelegate = (YourAppDelegateClass *)[[UIApplication sharedApplication] delegate];
+    //NSString *string = appDelegate.yourProperty;
+    
+    self.sharedManager = [APIManager sharedManager];
+    NSMutableArray *posts = [self.sharedManager.postCache objectForKey:@"posts"];
+    NSLog(@"Posts here: %@", posts);
+    
     [self fetchPostsViewed];
 }
 
@@ -106,7 +115,7 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString *post_id = self.filteredPostArray[indexPath.row][@"post_id"] ;
-    [self._apiManager getPostDictFromIDWithCompletion:post_id completion:^(NSDictionary * _Nonnull post, NSError * _Nonnull error) {
+    [self.sharedManager getPostDictFromIDWithCompletion:post_id completion:^(NSDictionary * _Nonnull post, NSError * _Nonnull error) {
         if (post) {
             NSLog(@"Hello, World!");
             
@@ -114,6 +123,7 @@
             PostDetailsViewController *rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"PostDetailsViewController"];
             Post *p = [[Post alloc] initWithDictionary:post];
             rootViewController.postInfo = p;
+            rootViewController.array = [self.sharedManager.postCache objectForKey:@"posts"];
             [self.navigationController pushViewController:rootViewController animated:YES];
             
         } else if (!error) {

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -30,11 +30,6 @@
     self.searchBar.delegate = self;
     self.postArray = [[NSMutableArray alloc] init];
     self.filteredPostArray = [[NSMutableArray alloc] init];
-    
-    
-    //YourAppDelegateClass *appDelegate = (YourAppDelegateClass *)[[UIApplication sharedApplication] delegate];
-    //NSString *string = appDelegate.yourProperty;
-    
     self.sharedManager = [APIManager sharedManager];
     NSMutableArray *posts = [self.sharedManager.postCache objectForKey:@"posts"];
     NSLog(@"Posts here: %@", posts);
@@ -123,7 +118,7 @@
             PostDetailsViewController *rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"PostDetailsViewController"];
             Post *p = [[Post alloc] initWithDictionary:post];
             rootViewController.postInfo = p;
-            rootViewController.array = [self.sharedManager.postCache objectForKey:@"posts"];
+            rootViewController.sharedManager = self.sharedManager;
             [self.navigationController pushViewController:rootViewController animated:YES];
             
         } else if (!error) {


### PR DESCRIPTION
### Description
This PR builds off of PR #33, which implements switching to the details view from a selected post in the search view. This PR fixes a blocker from before where the comments in the details view were not displayed. My solution was to create a singleton APIManager class, so that all class files can access the cache property that is part of the APIManager. Now, any view controller can access this cache by simply using this singleton class without having to use segue ways.

### Milestones
This feature adds on to the “Search through already-read posts using a search bar” feature, which will count towards the “Technically Ambiguous Problem” requirement.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/182775404-8d123834-efcf-48bd-8db6-a88538f4887f.mov

