### PR TITLE
Filter read posts

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -558,7 +558,7 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="xXY-kr-knt">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <searchBar key="tableHeaderView" contentMode="redraw" id="av8-r1-NkD">
+                                <searchBar key="tableHeaderView" contentMode="redraw" placeholder="Search by keyword or hold to filter posts" id="av8-r1-NkD">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                     <textInputTraits key="textInputTraits"/>

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -48,6 +48,7 @@
                 if (object != nil) {
                     NSLog(@"Duplicate object: %@", object);
                     [object incrementKey:@"times_viewed"];
+                    [object setValue:[NSDate date] forKey:@"read_date"];
                     [object saveInBackground];
                     [self fetchComments];
                 } else if (error == nil) {

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -14,6 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableArray *postArray;
 @property (nonatomic, strong) NSMutableArray *filteredPostArray;
+@property (assign, nonatomic) NSString *filter_string;
+
+@property (assign, nonatomic) NSPredicate *selected_predicate;
 
 @property (nonatomic, strong) APIManager *_apiManager;
 

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -42,6 +42,12 @@
         } else if (!error) {
             // no courses viewed
             NSLog(@"No courses viewed yet!");
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle: @ "No posts viewed!"
+                                                                              message: @"View posts in your feed to search by keyword" preferredStyle: UIAlertControllerStyleAlert];
+            UIAlertAction *action = [UIAlertAction actionWithTitle: @ "Dismiss"
+                                                              style: UIAlertActionStyleDefault handler: ^ (UIAlertAction *action) {}];
+            [alert addAction: action];
+            [self presentViewController: alert animated: true completion: nil];
         } else {
             NSLog(@"Error: %@", error.localizedDescription);
         }
@@ -108,8 +114,6 @@
     NSString *post_id = self.filteredPostArray[indexPath.row][@"post_id"] ;
     [self._apiManager getPostDictFromIDWithCompletion:post_id completion:^(NSDictionary * _Nonnull post, NSError * _Nonnull error) {
         if (post) {
-            NSLog(@"Hello, World!");
-            
             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
             PostDetailsViewController *rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"PostDetailsViewController"];
             Post *p = [[Post alloc] initWithDictionary:post];

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -30,6 +30,10 @@
     self.postArray = [[NSMutableArray alloc] init];
     self._apiManager = [[APIManager alloc] init];
     self.filteredPostArray = [[NSMutableArray alloc] init];
+    //[self fetchPostsViewed];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
     [self fetchPostsViewed];
 }
 
@@ -39,8 +43,7 @@
             self.postArray = [NSMutableArray arrayWithArray:result];
             self.filteredPostArray = self.postArray;
             [self.tableView reloadData];
-        } else if (!error) {
-            // no courses viewed
+        } else if (!error) {   // no courses viewed
             NSLog(@"No courses viewed yet!");
             UIAlertController *alert = [UIAlertController alertControllerWithTitle: @ "No posts viewed!"
                                                                               message: @"View posts in your feed to search by keyword" preferredStyle: UIAlertControllerStyleAlert];

--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ Finally, there will be a view for searching through posts that the user already 
     - The post and its information is saved as a object with a name that contains its user-id 
         - e.g. for a user with user-id = 12345, the post will be stored as an object called "user12345"
         - This makes mapping users to viewed posts easier, because we won't have to save posts and map each post to a user, then query all posts with a particular user-id field
+        
+        
+----- Monday, August 1 -----
+- Add 
+        
+        
+----- Tuesday, August 2 -----
+- Add 
+        
+
+----- Wednesday, August 3 -----
+
 
  
 ## Credits

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ Finally, there will be a view for searching through posts that the user already 
         - e.g. for a user with user-id = 12345, the post will be stored as an object called "user12345"
         - This makes mapping users to viewed posts easier, because we won't have to save posts and map each post to a user, then query all posts with a particular user-id field
 
-
  
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -137,17 +137,6 @@ Finally, there will be a view for searching through posts that the user already 
     - The post and its information is saved as a object with a name that contains its user-id 
         - e.g. for a user with user-id = 12345, the post will be stored as an object called "user12345"
         - This makes mapping users to viewed posts easier, because we won't have to save posts and map each post to a user, then query all posts with a particular user-id field
-        
-        
------ Monday, August 1 -----
-- Add 
-        
-        
------ Tuesday, August 2 -----
-- Add 
-        
-
------ Wednesday, August 3 -----
 
 
  


### PR DESCRIPTION
### Description
This PR builds off of PR #30, which implements typing a keyword into the search bar to search through read posts. The current PR implements filtering posts by category upon searching by keyword. To filter, the user can tap-and-hold on the search bar, which reveals a context menu with filter choices: all text (default), message, title, name, and course. Once a category is selected (if no category is selected, the default filter is used), typing a keyword into the search bar will filter all read posts by the selected category.

### Milestones
This feature adds on to the “Search through already-read posts using a search bar” feature, which will count towards the “Technically Ambiguous Problem” requirement.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/182775936-141a6088-9530-49ea-bd69-85314ee79464.mp4
