### PR TITLE
Layout fixes

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -179,8 +179,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
-                                <rect key="frame" x="20" y="104" width="374" height="30"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
+                                <rect key="frame" x="20" y="88" width="374" height="46"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="46" id="VXH-tm-SVw"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -277,6 +280,9 @@
                             </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2Q-ad-h1I">
                                 <rect key="frame" x="20" y="439" width="82" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="31" id="uTO-Nu-csF"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -311,7 +317,7 @@
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="8SL-sU-K9W" firstAttribute="top" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="17" id="0Pb-UJ-1cz"/>
-                            <constraint firstItem="6ZA-sR-0Ay" firstAttribute="top" secondItem="bRU-Qa-uYY" secondAttribute="top" constant="16" id="0X7-yf-Yow"/>
+                            <constraint firstItem="6ZA-sR-0Ay" firstAttribute="top" secondItem="bRU-Qa-uYY" secondAttribute="top" id="0X7-yf-Yow"/>
                             <constraint firstItem="y5W-ns-RF6" firstAttribute="leading" secondItem="BEg-Qw-3QV" secondAttribute="trailing" constant="21" id="2Ao-jL-u9l"/>
                             <constraint firstItem="87f-VR-vJw" firstAttribute="top" secondItem="y5W-ns-RF6" secondAttribute="bottom" constant="7" id="32F-sj-ptz"/>
                             <constraint firstItem="6ZA-sR-0Ay" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" constant="20" id="4JS-Ng-OAN"/>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -221,7 +221,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="cLz-zM-xIt">
-                                <rect key="frame" x="0.0" y="486.5" width="414" height="405"/>
+                                <rect key="frame" x="0.0" y="491" width="414" height="405"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="405" id="f8C-L5-koU"/>
@@ -276,13 +276,13 @@
                                 </prototypes>
                             </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2Q-ad-h1I">
-                                <rect key="frame" x="20" y="439" width="82" height="26.5"/>
+                                <rect key="frame" x="20" y="439" width="82" height="31"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VwJ-Dz-ude">
-                                <rect key="frame" x="20" y="477" width="374" height="1"/>
+                                <rect key="frame" x="20" y="481.5" width="374" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray3Color"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="nBb-IE-NhV"/>
@@ -328,7 +328,6 @@
                             <constraint firstItem="BEg-Qw-3QV" firstAttribute="top" secondItem="6ZA-sR-0Ay" secondAttribute="bottom" constant="17.5" id="Y2f-QV-iuI"/>
                             <constraint firstItem="87f-VR-vJw" firstAttribute="bottom" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="-0.5" id="ZH0-IB-WsZ"/>
                             <constraint firstItem="33p-eE-T9X" firstAttribute="top" secondItem="8SL-sU-K9W" secondAttribute="bottom" constant="7.5" id="a4z-v8-0Nv"/>
-                            <constraint firstItem="VwJ-Dz-ude" firstAttribute="top" secondItem="Quh-TJ-bpF" secondAttribute="top" constant="477" id="bSc-7X-9rV"/>
                             <constraint firstItem="cLz-zM-xIt" firstAttribute="top" secondItem="VwJ-Dz-ude" secondAttribute="bottom" constant="8.5" id="bf7-RS-kA5"/>
                             <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="VwJ-Dz-ude" secondAttribute="trailing" constant="20" id="cF9-6t-36J"/>
                             <constraint firstItem="I2Q-ad-h1I" firstAttribute="top" secondItem="33p-eE-T9X" secondAttribute="bottom" constant="7" id="eAh-tc-Jif"/>
@@ -464,28 +463,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Write something..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Z0y-oD-QlO">
-                                <rect key="frame" x="20" y="133" width="374" height="282"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Write something..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Z0y-oD-QlO">
+                                <rect key="frame" x="20" y="133" width="354" height="282"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="282" id="YDV-Bc-fZy"/>
-                                </constraints>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Title" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="axT-Pa-5g3">
-                                <rect key="frame" x="20" y="79" width="374" height="33"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Title" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="axT-Pa-5g3">
+                                <rect key="frame" x="20" y="79" width="354" height="33"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="33" id="APW-nH-SIf"/>
-                                </constraints>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btF-V8-ggi">
-                                <rect key="frame" x="290" y="437" width="104" height="36"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btF-V8-ggi">
+                                <rect key="frame" x="270" y="440" width="104" height="36"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Post">
                                     <fontDescription key="titleFontDescription" type="system" pointSize="18"/>
@@ -497,18 +493,6 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="1Zc-eU-7Mw"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="Z0y-oD-QlO" firstAttribute="leading" secondItem="axT-Pa-5g3" secondAttribute="leading" id="8j6-26-4m2"/>
-                            <constraint firstItem="1Zc-eU-7Mw" firstAttribute="trailing" secondItem="axT-Pa-5g3" secondAttribute="trailing" constant="20" id="G88-V5-83R"/>
-                            <constraint firstItem="axT-Pa-5g3" firstAttribute="top" secondItem="1Zc-eU-7Mw" secondAttribute="top" constant="23" id="Mcg-VG-fEj"/>
-                            <constraint firstItem="axT-Pa-5g3" firstAttribute="leading" secondItem="1Zc-eU-7Mw" secondAttribute="leading" constant="20" id="VdE-W7-mEp"/>
-                            <constraint firstItem="Z0y-oD-QlO" firstAttribute="top" secondItem="axT-Pa-5g3" secondAttribute="bottom" constant="21" id="WBz-op-cJ1"/>
-                            <constraint firstItem="btF-V8-ggi" firstAttribute="top" secondItem="Z0y-oD-QlO" secondAttribute="bottom" constant="22" id="ezO-Bm-Wcx"/>
-                            <constraint firstItem="btF-V8-ggi" firstAttribute="leading" secondItem="1Zc-eU-7Mw" secondAttribute="leading" constant="290" id="p61-hn-ag9"/>
-                            <constraint firstItem="Z0y-oD-QlO" firstAttribute="trailing" secondItem="axT-Pa-5g3" secondAttribute="trailing" id="wuK-L3-fNy"/>
-                            <constraint firstItem="1Zc-eU-7Mw" firstAttribute="trailing" secondItem="btF-V8-ggi" secondAttribute="trailing" constant="20" id="ygA-tY-YOg"/>
-                            <constraint firstItem="1Zc-eU-7Mw" firstAttribute="bottom" secondItem="btF-V8-ggi" secondAttribute="bottom" constant="369" id="zLK-Il-Wle"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Compose a Post" id="LmF-74-NWC">
                         <barButtonItem key="leftBarButtonItem" style="plain" id="rJJ-Wa-eLg">

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -179,41 +179,37 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
                                 <rect key="frame" x="20" y="104" width="374" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C7U-GX-NSk">
-                                <rect key="frame" x="20" y="255" width="374" height="106"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8SL-sU-K9W">
+                                <rect key="frame" x="0.0" y="238" width="414" height="171"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BEg-Qw-3QV">
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C7U-GX-NSk">
+                                        <rect key="frame" x="13" y="15" width="388" height="38"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <viewLayoutGuide key="contentLayoutGuide" id="sMq-aX-oOA"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="Xsd-aG-91Z"/>
+                            </scrollView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BEg-Qw-3QV">
                                 <rect key="frame" x="20" y="158" width="64" height="62"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="tintColor" red="0.47478711530000001" green="0.48709458709999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="87f-VR-vJw">
-                                <rect key="frame" x="108" y="193" width="286" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="87f-VR-vJw">
+                                <rect key="frame" x="108" y="193" width="286" height="29"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33p-eE-T9X">
-                                <rect key="frame" x="233" y="381" width="161" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Answer this Question"/>
-                                <connections>
-                                    <segue destination="z7o-os-hQ5" kind="presentation" identifier="answerSegue" id="Q7C-pp-3Tv"/>
-                                </connections>
-                            </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="cLz-zM-xIt">
                                 <rect key="frame" x="0.0" y="491" width="414" height="405"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -267,28 +263,50 @@
                                 </prototypes>
                             </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2Q-ad-h1I">
-                                <rect key="frame" x="20" y="435" width="82" height="27"/>
+                                <rect key="frame" x="20" y="451" width="82" height="27"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VwJ-Dz-ude">
-                                <rect key="frame" x="20" y="470" width="374" height="1"/>
+                                <rect key="frame" x="20" y="486" width="374" height="1"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemGray3Color"/>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y5W-ns-RF6">
-                                <rect key="frame" x="108" y="164" width="286" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y5W-ns-RF6">
+                                <rect key="frame" x="108" y="157" width="286" height="36"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33p-eE-T9X">
+                                <rect key="frame" x="233" y="417" width="161" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Answer this Question"/>
+                                <connections>
+                                    <segue destination="z7o-os-hQ5" kind="presentation" identifier="answerSegue" id="Q7C-pp-3Tv"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="bRU-Qa-uYY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <gestureRecognizers/>
+                        <constraints>
+                            <constraint firstItem="6ZA-sR-0Ay" firstAttribute="top" secondItem="bRU-Qa-uYY" secondAttribute="top" constant="16" id="0X7-yf-Yow"/>
+                            <constraint firstItem="y5W-ns-RF6" firstAttribute="leading" secondItem="BEg-Qw-3QV" secondAttribute="trailing" constant="24" id="2Ao-jL-u9l"/>
+                            <constraint firstItem="87f-VR-vJw" firstAttribute="top" secondItem="y5W-ns-RF6" secondAttribute="bottom" constant="7" id="32F-sj-ptz"/>
+                            <constraint firstItem="6ZA-sR-0Ay" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" constant="20" id="4JS-Ng-OAN"/>
+                            <constraint firstItem="y5W-ns-RF6" firstAttribute="top" secondItem="BEg-Qw-3QV" secondAttribute="top" id="4pi-CQ-07j"/>
+                            <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="6ZA-sR-0Ay" secondAttribute="trailing" constant="20" id="Bzv-ur-pAU"/>
+                            <constraint firstItem="87f-VR-vJw" firstAttribute="leading" secondItem="y5W-ns-RF6" secondAttribute="leading" id="QM8-Zm-bha"/>
+                            <constraint firstItem="y5W-ns-RF6" firstAttribute="trailing" secondItem="6ZA-sR-0Ay" secondAttribute="trailing" id="WP1-lq-zqB"/>
+                            <constraint firstItem="BEg-Qw-3QV" firstAttribute="top" secondItem="6ZA-sR-0Ay" secondAttribute="bottom" constant="17.5" id="Y2f-QV-iuI"/>
+                            <constraint firstItem="87f-VR-vJw" firstAttribute="bottom" secondItem="BEg-Qw-3QV" secondAttribute="bottom" id="ZH0-IB-WsZ"/>
+                            <constraint firstItem="87f-VR-vJw" firstAttribute="trailing" secondItem="y5W-ns-RF6" secondAttribute="trailing" id="nog-af-8BG"/>
+                            <constraint firstItem="BEg-Qw-3QV" firstAttribute="leading" secondItem="6ZA-sR-0Ay" secondAttribute="leading" id="ssT-W4-YgH"/>
+                        </constraints>
                         <connections>
                             <outletCollection property="gestureRecognizers" destination="kLQ-kW-MZB" appends="YES" id="tM7-2B-Hn8"/>
                         </connections>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -179,41 +179,54 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
-                                <rect key="frame" x="20" y="104" width="374" height="35"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
+                                <rect key="frame" x="20" y="104" width="374" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8SL-sU-K9W">
-                                <rect key="frame" x="0.0" y="238" width="414" height="171"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8SL-sU-K9W">
+                                <rect key="frame" x="0.0" y="223.5" width="414" height="171"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C7U-GX-NSk">
-                                        <rect key="frame" x="13" y="15" width="388" height="38"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Question Description" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C7U-GX-NSk">
+                                        <rect key="frame" x="13" y="15" width="160" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
+                                <color key="backgroundColor" red="0.92986940412630514" green="0.95838975362031642" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstItem="C7U-GX-NSk" firstAttribute="leading" secondItem="8SL-sU-K9W" secondAttribute="leading" constant="13" id="7sf-c9-TW5"/>
+                                    <constraint firstAttribute="bottom" secondItem="C7U-GX-NSk" secondAttribute="bottom" constant="118" id="CBo-wF-sxe"/>
+                                    <constraint firstAttribute="trailing" secondItem="C7U-GX-NSk" secondAttribute="trailing" constant="13" id="HwW-Mw-Et1"/>
+                                    <constraint firstItem="C7U-GX-NSk" firstAttribute="top" secondItem="8SL-sU-K9W" secondAttribute="top" constant="15" id="bSH-oc-lqN"/>
+                                    <constraint firstAttribute="height" constant="171" id="wWe-x8-hgu"/>
+                                </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="sMq-aX-oOA"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="Xsd-aG-91Z"/>
                             </scrollView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BEg-Qw-3QV">
-                                <rect key="frame" x="20" y="158" width="64" height="62"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BEg-Qw-3QV">
+                                <rect key="frame" x="20" y="153" width="55" height="52"/>
                                 <color key="tintColor" red="0.47478711530000001" green="0.48709458709999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="55" id="Afz-4c-NxR"/>
+                                    <constraint firstAttribute="width" constant="55" id="flE-XV-M0c"/>
+                                </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="87f-VR-vJw">
-                                <rect key="frame" x="108" y="193" width="286" height="29"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="87f-VR-vJw">
+                                <rect key="frame" x="96" y="180" width="286" height="26"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="cLz-zM-xIt">
-                                <rect key="frame" x="0.0" y="491" width="414" height="405"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="cLz-zM-xIt">
+                                <rect key="frame" x="0.0" y="486.5" width="414" height="405"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="405" id="f8C-L5-koU"/>
+                                </constraints>
+                                <color key="sectionIndexBackgroundColor" red="0.87929017549999999" green="0.92362233910000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CommentCell" rowHeight="104" id="B4x-OK-N2B" customClass="CommentCell">
                                         <rect key="frame" x="0.0" y="44.5" width="414" height="104"/>
@@ -223,20 +236,20 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gzX-ly-F4D">
-                                                    <rect key="frame" x="20" y="18" width="319" height="21.5"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                    <rect key="frame" x="20" y="18" width="320.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="22h" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcl-MG-RLZ">
-                                                    <rect key="frame" x="363" y="18" width="31" height="21.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                    <rect key="frame" x="364.5" y="18" width="29.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fSj-gh-yhv">
-                                                    <rect key="frame" x="20" y="61.5" width="374" height="22.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                    <rect key="frame" x="20" y="60.5" width="374" height="23.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -262,29 +275,32 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2Q-ad-h1I">
-                                <rect key="frame" x="20" y="451" width="82" height="27"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2Q-ad-h1I">
+                                <rect key="frame" x="20" y="439" width="82" height="26.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VwJ-Dz-ude">
-                                <rect key="frame" x="20" y="486" width="374" height="1"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VwJ-Dz-ude">
+                                <rect key="frame" x="20" y="477" width="374" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray3Color"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="nBb-IE-NhV"/>
+                                </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y5W-ns-RF6">
-                                <rect key="frame" x="108" y="157" width="286" height="36"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y5W-ns-RF6">
+                                <rect key="frame" x="96" y="151.5" width="286" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33p-eE-T9X">
-                                <rect key="frame" x="233" y="417" width="161" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33p-eE-T9X">
+                                <rect key="frame" x="237" y="402" width="157" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="117" id="Kdw-ur-XxG"/>
+                                </constraints>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Answer this Question"/>
+                                <buttonConfiguration key="configuration" style="plain" image="pencil.and.ellipsis.rectangle" catalog="system" title="Answer"/>
                                 <connections>
                                     <segue destination="z7o-os-hQ5" kind="presentation" identifier="answerSegue" id="Q7C-pp-3Tv"/>
                                 </connections>
@@ -294,18 +310,36 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <gestureRecognizers/>
                         <constraints>
+                            <constraint firstItem="8SL-sU-K9W" firstAttribute="top" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="17" id="0Pb-UJ-1cz"/>
                             <constraint firstItem="6ZA-sR-0Ay" firstAttribute="top" secondItem="bRU-Qa-uYY" secondAttribute="top" constant="16" id="0X7-yf-Yow"/>
-                            <constraint firstItem="y5W-ns-RF6" firstAttribute="leading" secondItem="BEg-Qw-3QV" secondAttribute="trailing" constant="24" id="2Ao-jL-u9l"/>
+                            <constraint firstItem="y5W-ns-RF6" firstAttribute="leading" secondItem="BEg-Qw-3QV" secondAttribute="trailing" constant="21" id="2Ao-jL-u9l"/>
                             <constraint firstItem="87f-VR-vJw" firstAttribute="top" secondItem="y5W-ns-RF6" secondAttribute="bottom" constant="7" id="32F-sj-ptz"/>
                             <constraint firstItem="6ZA-sR-0Ay" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" constant="20" id="4JS-Ng-OAN"/>
                             <constraint firstItem="y5W-ns-RF6" firstAttribute="top" secondItem="BEg-Qw-3QV" secondAttribute="top" id="4pi-CQ-07j"/>
+                            <constraint firstItem="cLz-zM-xIt" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" id="51K-Ze-Gfe"/>
+                            <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="33p-eE-T9X" secondAttribute="trailing" constant="20" id="5EB-D8-wJI"/>
                             <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="6ZA-sR-0Ay" secondAttribute="trailing" constant="20" id="Bzv-ur-pAU"/>
+                            <constraint firstItem="33p-eE-T9X" firstAttribute="leading" secondItem="I2Q-ad-h1I" secondAttribute="trailing" constant="135" id="D56-64-csb"/>
+                            <constraint firstItem="I2Q-ad-h1I" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" constant="20" id="J1P-l3-hxG"/>
                             <constraint firstItem="87f-VR-vJw" firstAttribute="leading" secondItem="y5W-ns-RF6" secondAttribute="leading" id="QM8-Zm-bha"/>
-                            <constraint firstItem="y5W-ns-RF6" firstAttribute="trailing" secondItem="6ZA-sR-0Ay" secondAttribute="trailing" id="WP1-lq-zqB"/>
+                            <constraint firstItem="8SL-sU-K9W" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" id="Seb-R5-C9U"/>
+                            <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="cLz-zM-xIt" secondAttribute="trailing" id="VMj-my-3mB"/>
+                            <constraint firstItem="y5W-ns-RF6" firstAttribute="trailing" secondItem="6ZA-sR-0Ay" secondAttribute="trailing" constant="-12" id="WP1-lq-zqB"/>
                             <constraint firstItem="BEg-Qw-3QV" firstAttribute="top" secondItem="6ZA-sR-0Ay" secondAttribute="bottom" constant="17.5" id="Y2f-QV-iuI"/>
-                            <constraint firstItem="87f-VR-vJw" firstAttribute="bottom" secondItem="BEg-Qw-3QV" secondAttribute="bottom" id="ZH0-IB-WsZ"/>
+                            <constraint firstItem="87f-VR-vJw" firstAttribute="bottom" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="-0.5" id="ZH0-IB-WsZ"/>
+                            <constraint firstItem="33p-eE-T9X" firstAttribute="top" secondItem="8SL-sU-K9W" secondAttribute="bottom" constant="7.5" id="a4z-v8-0Nv"/>
+                            <constraint firstItem="VwJ-Dz-ude" firstAttribute="top" secondItem="Quh-TJ-bpF" secondAttribute="top" constant="477" id="bSc-7X-9rV"/>
+                            <constraint firstItem="cLz-zM-xIt" firstAttribute="top" secondItem="VwJ-Dz-ude" secondAttribute="bottom" constant="8.5" id="bf7-RS-kA5"/>
+                            <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="VwJ-Dz-ude" secondAttribute="trailing" constant="20" id="cF9-6t-36J"/>
+                            <constraint firstItem="I2Q-ad-h1I" firstAttribute="top" secondItem="33p-eE-T9X" secondAttribute="bottom" constant="7" id="eAh-tc-Jif"/>
+                            <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="8SL-sU-K9W" secondAttribute="trailing" id="hTe-JI-bVU"/>
+                            <constraint firstItem="VwJ-Dz-ude" firstAttribute="top" secondItem="I2Q-ad-h1I" secondAttribute="bottom" constant="11.5" id="mfb-ot-BAJ"/>
                             <constraint firstItem="87f-VR-vJw" firstAttribute="trailing" secondItem="y5W-ns-RF6" secondAttribute="trailing" id="nog-af-8BG"/>
+                            <constraint firstItem="cLz-zM-xIt" firstAttribute="bottom" secondItem="bRU-Qa-uYY" secondAttribute="bottom" constant="83" id="qeK-Xc-Z7O"/>
                             <constraint firstItem="BEg-Qw-3QV" firstAttribute="leading" secondItem="6ZA-sR-0Ay" secondAttribute="leading" id="ssT-W4-YgH"/>
+                            <constraint firstItem="8SL-sU-K9W" firstAttribute="width" secondItem="Quh-TJ-bpF" secondAttribute="width" id="uI0-lk-ucb"/>
+                            <constraint firstItem="VwJ-Dz-ude" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" constant="20" id="uZa-LY-M4r"/>
+                            <constraint firstItem="I2Q-ad-h1I" firstAttribute="top" secondItem="8SL-sU-K9W" secondAttribute="bottom" constant="44.5" id="yzf-CA-n7P"/>
                         </constraints>
                         <connections>
                             <outletCollection property="gestureRecognizers" destination="kLQ-kW-MZB" appends="YES" id="tM7-2B-Hn8"/>
@@ -339,40 +373,38 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dxb-38-TcQ">
-                                <rect key="frame" x="20" y="123" width="374" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dxb-38-TcQ">
+                                <rect key="frame" x="20" y="123" width="374" height="26.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Question Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Px-Zj-XRE">
-                                <rect key="frame" x="20" y="161" width="374" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Question Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Px-Zj-XRE">
+                                <rect key="frame" x="20" y="166.5" width="374" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Your answer" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="yPG-bq-hBs">
-                                <rect key="frame" x="20" y="229" width="355" height="327"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Your answer" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="yPG-bq-hBs">
+                                <rect key="frame" x="20" y="239" width="374" height="317"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Answering _'s Question:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vif-YW-0bH">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Answering _'s Question:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vif-YW-0bH">
                                 <rect key="frame" x="20" y="71" width="374" height="18"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.23636350649999999" green="0.3408852644" blue="0.76393363400000003" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eot-bc-ksx">
-                                <rect key="frame" x="294" y="589" width="100" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eot-bc-ksx">
+                                <rect key="frame" x="228" y="589" width="166" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="135" id="Ysl-W5-o38"/>
+                                </constraints>
                                 <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Respond"/>
+                                <buttonConfiguration key="configuration" style="plain" image="rectangle.and.pencil.and.ellipsis" catalog="system" title="Respond"/>
                                 <connections>
                                     <action selector="didTapRespond:" destination="cRq-wp-yDg" eventType="touchUpInside" id="W2K-ZH-FGT"/>
                                 </connections>
@@ -380,6 +412,24 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="2AA-nj-rcc"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Vif-YW-0bH" firstAttribute="leading" secondItem="2AA-nj-rcc" secondAttribute="leading" constant="20" id="1SJ-z0-Q7v"/>
+                            <constraint firstItem="dxb-38-TcQ" firstAttribute="trailing" secondItem="Vif-YW-0bH" secondAttribute="trailing" id="2ot-jL-SWw"/>
+                            <constraint firstItem="2AA-nj-rcc" firstAttribute="bottom" secondItem="eot-bc-ksx" secondAttribute="bottom" constant="222" id="5a1-5p-tFk"/>
+                            <constraint firstItem="eot-bc-ksx" firstAttribute="leading" secondItem="2AA-nj-rcc" secondAttribute="leading" constant="228" id="B1a-7n-7sn"/>
+                            <constraint firstItem="3Px-Zj-XRE" firstAttribute="top" secondItem="dxb-38-TcQ" secondAttribute="bottom" constant="17" id="G36-g3-vvO"/>
+                            <constraint firstItem="2AA-nj-rcc" firstAttribute="trailing" secondItem="eot-bc-ksx" secondAttribute="trailing" constant="20" id="HAU-Yx-H25"/>
+                            <constraint firstItem="3Px-Zj-XRE" firstAttribute="trailing" secondItem="dxb-38-TcQ" secondAttribute="trailing" id="MJ0-xd-t7X"/>
+                            <constraint firstItem="eot-bc-ksx" firstAttribute="top" secondItem="yPG-bq-hBs" secondAttribute="bottom" constant="33" id="MZf-x8-aaL"/>
+                            <constraint firstItem="yPG-bq-hBs" firstAttribute="top" secondItem="3Px-Zj-XRE" secondAttribute="bottom" constant="52" id="RJk-Ob-udR"/>
+                            <constraint firstItem="Vif-YW-0bH" firstAttribute="top" secondItem="2AA-nj-rcc" secondAttribute="top" constant="15" id="TTU-8H-JTb"/>
+                            <constraint firstItem="yPG-bq-hBs" firstAttribute="leading" secondItem="3Px-Zj-XRE" secondAttribute="leading" id="Tqg-Ku-Kk4"/>
+                            <constraint firstItem="3Px-Zj-XRE" firstAttribute="leading" secondItem="dxb-38-TcQ" secondAttribute="leading" id="aLn-hM-yGS"/>
+                            <constraint firstItem="2AA-nj-rcc" firstAttribute="trailing" secondItem="Vif-YW-0bH" secondAttribute="trailing" constant="20" id="bR6-yj-yer"/>
+                            <constraint firstItem="dxb-38-TcQ" firstAttribute="leading" secondItem="Vif-YW-0bH" secondAttribute="leading" id="gJB-Mg-8fy"/>
+                            <constraint firstItem="yPG-bq-hBs" firstAttribute="trailing" secondItem="3Px-Zj-XRE" secondAttribute="trailing" id="w1H-aA-V8T"/>
+                            <constraint firstItem="dxb-38-TcQ" firstAttribute="top" secondItem="Vif-YW-0bH" secondAttribute="bottom" constant="34" id="x5i-eM-21w"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="fdh-vX-rEK">
                         <barButtonItem key="leftBarButtonItem" style="plain" id="Xod-G2-fc9">
@@ -414,25 +464,31 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Write something..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Z0y-oD-QlO">
-                                <rect key="frame" x="20" y="133" width="350" height="282"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Write something..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Z0y-oD-QlO">
+                                <rect key="frame" x="20" y="133" width="374" height="282"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="282" id="YDV-Bc-fZy"/>
+                                </constraints>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="Title" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="axT-Pa-5g3">
-                                <rect key="frame" x="20" y="79" width="350" height="33"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Title" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="axT-Pa-5g3">
+                                <rect key="frame" x="20" y="79" width="374" height="33"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="33" id="APW-nH-SIf"/>
+                                </constraints>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btF-V8-ggi">
-                                <rect key="frame" x="310" y="437" width="60" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btF-V8-ggi">
+                                <rect key="frame" x="310" y="437" width="84" height="36"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="d8X-ZX-PnP"/>
+                                </constraints>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Post">
                                     <fontDescription key="titleFontDescription" type="system" pointSize="18"/>
@@ -444,6 +500,18 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="1Zc-eU-7Mw"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Z0y-oD-QlO" firstAttribute="leading" secondItem="axT-Pa-5g3" secondAttribute="leading" id="8j6-26-4m2"/>
+                            <constraint firstItem="1Zc-eU-7Mw" firstAttribute="trailing" secondItem="axT-Pa-5g3" secondAttribute="trailing" constant="20" id="G88-V5-83R"/>
+                            <constraint firstItem="axT-Pa-5g3" firstAttribute="top" secondItem="1Zc-eU-7Mw" secondAttribute="top" constant="23" id="Mcg-VG-fEj"/>
+                            <constraint firstItem="axT-Pa-5g3" firstAttribute="leading" secondItem="1Zc-eU-7Mw" secondAttribute="leading" constant="20" id="VdE-W7-mEp"/>
+                            <constraint firstItem="Z0y-oD-QlO" firstAttribute="top" secondItem="axT-Pa-5g3" secondAttribute="bottom" constant="21" id="WBz-op-cJ1"/>
+                            <constraint firstItem="btF-V8-ggi" firstAttribute="top" secondItem="Z0y-oD-QlO" secondAttribute="bottom" constant="22" id="ezO-Bm-Wcx"/>
+                            <constraint firstItem="btF-V8-ggi" firstAttribute="leading" secondItem="1Zc-eU-7Mw" secondAttribute="leading" constant="310" id="p61-hn-ag9"/>
+                            <constraint firstItem="Z0y-oD-QlO" firstAttribute="trailing" secondItem="axT-Pa-5g3" secondAttribute="trailing" id="wuK-L3-fNy"/>
+                            <constraint firstItem="1Zc-eU-7Mw" firstAttribute="trailing" secondItem="btF-V8-ggi" secondAttribute="trailing" constant="20" id="ygA-tY-YOg"/>
+                            <constraint firstItem="1Zc-eU-7Mw" firstAttribute="bottom" secondItem="btF-V8-ggi" secondAttribute="bottom" constant="369" id="zLK-Il-Wle"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Compose a Post" id="LmF-74-NWC">
                         <barButtonItem key="leftBarButtonItem" style="plain" id="rJJ-Wa-eLg">
@@ -821,7 +889,9 @@
         <image name="books.vertical" catalog="system" width="128" height="107"/>
         <image name="house" catalog="system" width="128" height="106"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
+        <image name="pencil.and.ellipsis.rectangle" catalog="system" width="128" height="81"/>
         <image name="person.fill" catalog="system" width="128" height="120"/>
+        <image name="rectangle.and.pencil.and.ellipsis" catalog="system" width="128" height="81"/>
         <image name="square.and.pencil" catalog="system" width="128" height="115"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -485,10 +485,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btF-V8-ggi">
-                                <rect key="frame" x="310" y="437" width="84" height="36"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="84" id="d8X-ZX-PnP"/>
-                                </constraints>
+                                <rect key="frame" x="290" y="437" width="104" height="36"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Post">
                                     <fontDescription key="titleFontDescription" type="system" pointSize="18"/>
@@ -507,7 +504,7 @@
                             <constraint firstItem="axT-Pa-5g3" firstAttribute="leading" secondItem="1Zc-eU-7Mw" secondAttribute="leading" constant="20" id="VdE-W7-mEp"/>
                             <constraint firstItem="Z0y-oD-QlO" firstAttribute="top" secondItem="axT-Pa-5g3" secondAttribute="bottom" constant="21" id="WBz-op-cJ1"/>
                             <constraint firstItem="btF-V8-ggi" firstAttribute="top" secondItem="Z0y-oD-QlO" secondAttribute="bottom" constant="22" id="ezO-Bm-Wcx"/>
-                            <constraint firstItem="btF-V8-ggi" firstAttribute="leading" secondItem="1Zc-eU-7Mw" secondAttribute="leading" constant="310" id="p61-hn-ag9"/>
+                            <constraint firstItem="btF-V8-ggi" firstAttribute="leading" secondItem="1Zc-eU-7Mw" secondAttribute="leading" constant="290" id="p61-hn-ag9"/>
                             <constraint firstItem="Z0y-oD-QlO" firstAttribute="trailing" secondItem="axT-Pa-5g3" secondAttribute="trailing" id="wuK-L3-fNy"/>
                             <constraint firstItem="1Zc-eU-7Mw" firstAttribute="trailing" secondItem="btF-V8-ggi" secondAttribute="trailing" constant="20" id="ygA-tY-YOg"/>
                             <constraint firstItem="1Zc-eU-7Mw" firstAttribute="bottom" secondItem="btF-V8-ggi" secondAttribute="bottom" constant="369" id="zLK-Il-Wle"/>

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -36,6 +36,10 @@
     self.postsToBeCached = [[NSMutableArray alloc] init];
     self.isMoreDataLoading = NO;
     
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    NSString *course_id = [saved stringForKey:@"currentCourseAbbr"];
+    self.navigationItem.title = [NSString stringWithFormat:@"%@ Home", course_id];
+    
     // Initialize a UIRefreshControl
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(fetchPosts:) forControlEvents:UIControlEventValueChanged];

--- a/CapstoneProject/View Controllers/TabBarViewController.m
+++ b/CapstoneProject/View Controllers/TabBarViewController.m
@@ -16,6 +16,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     [self.navigationController setNavigationBarHidden:YES animated:YES];
+    self.tabBar.barTintColor = UIColor.whiteColor;
 }
 
 @end


### PR DESCRIPTION
### Description
This PR fixes some of the auto layouts for view controllers where text was cut off. It also changes the title text of the feed so that the current course is displayed for better user experience.

Some blockers:
- Although the table view is fully displayed after the fix, the title no longer shows up in the details view.
- Adding auto layout to the “composing post view controller” makes the “Post” button unclickable. I left out the auto layout for this view controller for now, and will create a status update about this blocker tomorrow.

### Milestones
N/A — this feature fixes some previous UI issues.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/182776140-e5867298-1a32-4415-bb4d-1c0da80df63d.mov

