### PR TITLE
Added sort menu and read date sort

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -627,7 +627,7 @@
             </objects>
             <point key="canvasLocation" x="2793" y="873"/>
         </scene>
-        <!--Search Recent History-->
+        <!--Search History-->
         <scene sceneID="wO1-tf-LAY">
             <objects>
                 <viewController id="S2i-p9-Ogb" customClass="SearchPostsViewController" sceneMemberID="viewController">
@@ -716,9 +716,19 @@
                             <constraint firstItem="18t-my-UA0" firstAttribute="top" secondItem="xXY-kr-knt" secondAttribute="top" constant="88" id="v0J-Px-CYy"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="Search Recent History" id="WoV-Rr-g9F"/>
+                    <navigationItem key="navigationItem" title="Search History" id="WoV-Rr-g9F">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="cC3-co-g8W">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="IuM-ir-xJD">
+                                <rect key="frame" x="302" y="5" width="92" height="34.5"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" image="shuffle" catalog="system"/>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="searchBar" destination="av8-r1-NkD" id="64a-yt-miq"/>
+                        <outlet property="sortButton" destination="IuM-ir-xJD" id="afr-fL-i9s"/>
                         <outlet property="tableView" destination="xXY-kr-knt" id="TEJ-1S-2v3"/>
                     </connections>
                 </viewController>
@@ -886,6 +896,7 @@
         <image name="pencil.and.ellipsis.rectangle" catalog="system" width="128" height="81"/>
         <image name="person.fill" catalog="system" width="128" height="120"/>
         <image name="rectangle.and.pencil.and.ellipsis" catalog="system" width="128" height="81"/>
+        <image name="shuffle" catalog="system" width="128" height="95"/>
         <image name="square.and.pencil" catalog="system" width="128" height="115"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -53,7 +53,7 @@
         if ([result count] != 0) {
             self.postArray = [NSMutableArray arrayWithArray:result];
             self.filteredPostArray = self.postArray;
-            [self sortByReadDateDefault];   // [self.tableView reloadData] called here
+            [self sortBy:@"read_date"];   // [self.tableView reloadData] called here
         } else if (!error) {   // no courses viewed
             NSLog(@"No courses viewed yet!");
             UIAlertController *alert = [UIAlertController alertControllerWithTitle: @ "No posts viewed!"
@@ -99,9 +99,9 @@
     return cell;
 }
 
-- (void)sortByReadDateDefault {
+- (void)sortBy:(NSString *)field {
     self.filteredPostArray = [NSMutableArray arrayWithArray:[self.filteredPostArray sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-        return [obj2[@"read_date"] compare:obj1[@"read_date"]];
+        return [obj2[field] compare:obj1[field]];
     }]];
     [self.tableView reloadData];
 }
@@ -109,12 +109,18 @@
 - (void)setSortButtonMenu {
     [self.sortButton setShowsMenuAsPrimaryAction:YES];
     UIAction *readDateSort = [UIAction actionWithTitle:@"Read date (default)" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
-        [self sortByReadDateDefault];
+        [self sortBy:@"read_date"];
+    }];
+    UIAction *postDateSort = [UIAction actionWithTitle:@"Post Date" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
+        [self sortBy:@"createdAt"];
+    }];
+    UIAction *timesViewedSort = [UIAction actionWithTitle:@"Times You Viewed" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
+        [self sortBy:@"times_viewed"];
     }];
     UIAction *customizedSort = [UIAction actionWithTitle:@"Customized" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
-        [self sortByReadDateDefault];
+        // TODO: implement customized sorting algorithm
     }];
-    self.sortButton.menu = [UIMenu menuWithTitle:@"Sort by: " children:@[readDateSort, customizedSort]];
+    self.sortButton.menu = [UIMenu menuWithTitle:@"Sort by: " children:@[readDateSort, postDateSort, timesViewedSort, customizedSort]];
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -18,6 +18,8 @@
 
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
+@property (weak, nonatomic) IBOutlet UIButton *sortButton;
+
 
 @end
 
@@ -34,6 +36,8 @@
     
     UIContextMenuInteraction *interaction = [[UIContextMenuInteraction alloc] initWithDelegate:self];
     [self.searchBar addInteraction:interaction];
+    
+    [self setSortButtonMenu];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -49,7 +53,7 @@
         if ([result count] != 0) {
             self.postArray = [NSMutableArray arrayWithArray:result];
             self.filteredPostArray = self.postArray;
-            [self.tableView reloadData];
+            [self sortByReadDateDefault];   // [self.tableView reloadData] called here
         } else if (!error) {   // no courses viewed
             NSLog(@"No courses viewed yet!");
             UIAlertController *alert = [UIAlertController alertControllerWithTitle: @ "No posts viewed!"
@@ -93,6 +97,24 @@
     [cell setSearchPostCell:self.filteredPostArray[indexPath.row]];
     
     return cell;
+}
+
+- (void)sortByReadDateDefault {
+    self.filteredPostArray = [NSMutableArray arrayWithArray:[self.filteredPostArray sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+        return [obj2[@"read_date"] compare:obj1[@"read_date"]];
+    }]];
+    [self.tableView reloadData];
+}
+
+- (void)setSortButtonMenu {
+    [self.sortButton setShowsMenuAsPrimaryAction:YES];
+    UIAction *readDateSort = [UIAction actionWithTitle:@"Read date (default)" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
+        [self sortByReadDateDefault];
+    }];
+    UIAction *customizedSort = [UIAction actionWithTitle:@"Customized" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
+        [self sortByReadDateDefault];
+    }];
+    self.sortButton.menu = [UIMenu menuWithTitle:@"Sort by: " children:@[readDateSort, customizedSort]];
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {
@@ -147,7 +169,7 @@
 
 
 - (nullable UIContextMenuConfiguration *)contextMenuInteraction:(nonnull UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location {
-    
+
     UIContextMenuConfiguration *config = [UIContextMenuConfiguration configurationWithIdentifier:nil previewProvider:nil actionProvider:^UIMenu * _Nullable(NSArray<UIMenuElement *> * _Nonnull suggestedActions) {
         
         UIAction *defaultFilter = [UIAction actionWithTitle:@"All text (default)" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {


### PR DESCRIPTION
### Description
This PR adds a sorting functionality to the view controller for filtering shown in #35. The user can press on a button to reveal a context menu with buttons for sorting by read date, post date, number of times viewed, and a custom sort. The first three types of sort are implemented in this PR. The last “custom sort” button will later have a sorting algorithm that sorts posts depending on the viewing tendencies of the user.

### Milestones
This feature fulfills the requirement “Sort posts in search view by order of how likely the user is to read each post”, which is part of technically ambiguous problem 2.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/183236991-3cf0037a-5513-414d-b4e7-a8be43a0804a.mp4
