### PR TITLE
Sort from history

### DIFF
--- a/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject.xcodeproj/project.pbxproj
@@ -200,6 +200,13 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		BE88045E28A07C5A00CAB4F3 /* Sorting Algorithms */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "Sorting Algorithms";
+			sourceTree = "<group>";
+		};
 		BEA4666828781C0400D57C23 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -265,6 +272,7 @@
 				BEDF114E2874FA0A00B080A4 /* AppDelegate.m */,
 				BEDF11502874FA0A00B080A4 /* SceneDelegate.h */,
 				BEDF11512874FA0A00B080A4 /* SceneDelegate.m */,
+				BE88045E28A07C5A00CAB4F3 /* Sorting Algorithms */,
 				BE166FE3289254270062D0CF /* API Manager */,
 				BEB9214E28850834004FA147 /* SpriteKit Scenes */,
 				BE8277D8287C91040059B509 /* Models */,

--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -25,9 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)createNewWordMappingForCurrentUser:(NSMutableDictionary *)dict;
 
-- (void)updateSearchedWordProbabilities:(NSString *)text;
+- (void)updateSearchedWordFrequencies:(NSString *)text;
 
-- (void)getSearchedWordProbabilitiesWithCompletion:(void(^)(NSMutableDictionary *wordCounts, NSError *error))completion;
+- (void)getSearchedWordFrequenciesWithCompletion:(void(^)(NSMutableDictionary *wordCounts, NSError *error))completion;
 
 @end
 

--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "Parse/Parse.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,13 +22,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion;
 
-- (NSMutableDictionary *)getWordMappingFromText;
+- (NSArray *)getWordMappingFromText:(NSString *)text;
 
-- (void)createNewWordMappingForCurrentUser:(NSMutableDictionary *)dict;
+- (void)createNewWordMappingForCurrentUser:(NSMutableDictionary *)dict incrementBy:(NSNumber *)count;
 
 - (void)updateSearchedWordFrequencies:(NSString *)text;
 
 - (void)getSearchedWordFrequenciesWithCompletion:(void(^)(NSMutableDictionary *wordCounts, NSError *error))completion;
+
+- (void)getSearchDataWithCompletion:(void(^)(PFObject *data, NSError *error))completion;
 
 @end
 

--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -21,6 +21,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion;
 
+- (NSMutableDictionary *)getWordMappingFromText;
+
+- (void)createNewWordMappingForCurrentUser:(NSMutableDictionary *)dict;
+
+- (void)updateSearchedWordProbabilities:(NSString *)text;
+
+- (void)getSearchedWordProbabilitiesWithCompletion:(void(^)(NSMutableDictionary *wordCounts, NSError *error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -8,6 +8,7 @@
 #import "APIManager.h"
 #import "FBSDKCoreKit/FBSDKCoreKit.h"
 #import "Post.h"
+#import "Parse/Parse.h"
 
 @implementation APIManager
 
@@ -82,6 +83,25 @@
             completion(posts, [dateFormat stringFromDate:((Post *)[posts lastObject]).post_date], nil);
         } else {
             completion(nil, nil, error);
+        }
+    }];
+}
+
+- (void)updateSearchedWordProbabilities:(NSString *)text {
+    
+}
+
+- (void *)getSearchedWordProbabilitiesWithCompletioncompletion:(void(^)(NSMutableDictionary *wordCounts, NSError *error))completion {
+    PFQuery *query = [PFQuery queryWithClassName:@"SearchedPosts"];
+    [query whereKey:@"user_id" equalTo:[FBSDKAccessToken currentAccessToken].userID];
+    query.limit = 1;
+
+    // fetch data asynchronously
+    [query findObjectsInBackgroundWithBlock:^(NSArray *result, NSError *error) {
+        if (result != nil) {
+            return 
+        } else {
+            NSLog(@"Error: %@", error.localizedDescription);
         }
     }];
 }

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -14,11 +14,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableArray *postArray;
 @property (nonatomic, strong) NSMutableArray *filteredPostArray;
+@property (nonatomic, strong) NSMutableArray *recommendedArray;
 @property (assign, nonatomic) NSString *filter_string;
 
 @property (assign, nonatomic) NSPredicate *selected_predicate;
 
 @property (nonatomic, strong) APIManager *sharedManager;
+
+@property (nonatomic, strong) NSMutableDictionary *wordCountDict;
+
+- (void)countWordsForSearchedPosts:(NSString *)postRead;
 
 @end
 

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -21,8 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) APIManager *sharedManager;
 
-@property (nonatomic, strong) NSMutableDictionary *wordCountDict;
-
 @property (nonatomic, strong) NSMutableDictionary *toSort;
 
 @end

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableDictionary *wordCountDict;
 
+@property (nonatomic, strong) NSMutableDictionary *toSort;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/View Controllers/SearchPostsViewController.h
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.h
@@ -23,8 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableDictionary *wordCountDict;
 
-- (void)countWordsForSearchedPosts:(NSString *)postRead;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -171,13 +171,12 @@
     [self.tableView reloadData];
 }
 
-
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString *post_id = self.filteredPostArray[indexPath.row][@"post_id"] ;
     NSString *allText = [NSString stringWithFormat:@"%@%@%@",
                          self.filteredPostArray[indexPath.row][@"title"], @" ",
                          self.filteredPostArray[indexPath.row][@"message"]];
-    [self.sharedManager updateSearchedWordProbabilities:allText];
+    [self.sharedManager updateSearchedWordFrequencies:allText];
     [self.sharedManager getPostDictFromIDWithCompletion:post_id completion:^(NSDictionary * _Nonnull post, NSError * _Nonnull error) {
         if (post) {
             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -74,7 +74,8 @@
     NSString *userInParse = [NSString stringWithFormat:@"%@%@", @"user", current_user_id];
     
     PFQuery *query = [PFQuery queryWithClassName:userInParse];
-    query.limit = 20;
+    [query orderByDescending:@"read_date"];
+    query.limit = 10;
 
     [query findObjectsInBackgroundWithBlock:^(NSArray *posts, NSError *error) {
         if (posts != nil) {
@@ -94,10 +95,22 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     SearchPostCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"SearchPostCell"
-                                                                 forIndexPath:indexPath];
+                                                                forIndexPath:indexPath];
     [cell setSearchPostCell:self.filteredPostArray[indexPath.row]];
     
     return cell;
+}
+
+- (NSArray *)findHighestPriorityPosts {
+    NSMutableArray *finalPosts = self.filteredPostArray;
+    
+    return finalPosts;
+}
+
+- (void)calculateProbabilities {
+    for (PFObject* post in self.filteredPostArray) {
+        
+    }
 }
 
 - (void)createNewReadPost:(NSMutableDictionary *)dict {
@@ -116,6 +129,57 @@
         }
     }];
 }
+
+- (NSInteger)getWordMatchScore:(NSDictionary *)dict1 firstCount:(NSInteger)count1 secondDictionary:(NSDictionary *)dict2 secondCount:(NSDictionary *)count2 {
+    NSInteger score = 0;
+    for (NSString* word in dict2) {
+        
+        
+        /*
+         
+         if (![word isEqualToString:@""]) {
+             if ([wordCountDict objectForKey:word]) {
+                 NSInteger count = (NSInteger)[wordCountDict valueForKey:word] + 1;
+                 [wordCountDict setObject:[NSNumber numberWithInt:(int)count] forKey:word];
+             } else {
+                 [wordCountDict setObject:@1 forKey:word];
+             }
+         }
+         
+         */
+    }
+    return score;
+}
+
+// Instead of sortBy in fetchPostsViewed
+- (void)sortByRecommendation {
+    for (PFObject* post in self.filteredPostArray) {
+        NSString *allText = [NSString stringWithFormat:@"%@%@%@",
+                             post[@"title"], @" ",
+                             post[@"message"]];
+        NSArray *viewedPostWords = [self.sharedManager getWordMappingFromText:allText];
+        NSDictionary *viewedWordMappings = viewedPostWords[0];
+        NSNumber *viewedCount = viewedPostWords[1];
+        
+        [self.sharedManager getSearchDataWithCompletion:^(PFObject * _Nonnull data, NSError * _Nonnull error) {
+            if (!error) {
+                NSDictionary *searchedWordMappings = data[@"word_counts"];
+                NSNumber *count = data[@"total_wordcount"];
+                
+                
+                
+            } else {
+                
+            }
+        }];
+    }
+    // for every post in filteredArray
+    //    put all unique words into array
+    //       for every word in array
+    //           if str is in searched words
+    //               multiply
+}
+
 
 - (void)sortBy:(NSString *)field {
     self.filteredPostArray = [NSMutableArray arrayWithArray:[self.filteredPostArray sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -33,7 +33,6 @@
     self.postArray = [[NSMutableArray alloc] init];
     self.filteredPostArray = [[NSMutableArray alloc] init];
     self.filter_string = @"DEFAULT";
-    self.wordCountDict = [[NSMutableDictionary alloc] init];
     self.toSort = [[NSMutableDictionary alloc] init];
     
     UIContextMenuInteraction *interaction = [[UIContextMenuInteraction alloc] initWithDelegate:self];
@@ -65,7 +64,6 @@
             }];
             self.filteredPostArray = [NSMutableArray arrayWithArray:sortedKeys];
             [self.tableView reloadData];
-            //[self sortBy:@"read_date"];   [self.tableView reloadData] called here
         } else if (!error) {   // no courses viewed
             NSLog(@"No courses viewed yet!");
             UIAlertController *alert = [UIAlertController alertControllerWithTitle: @ "No posts viewed!"
@@ -115,8 +113,6 @@
 - (void)createNewReadPost:(NSMutableDictionary *)dict {
     PFObject *searchedPost = [[PFObject alloc] initWithClassName:@"SearchedPosts"];
     
-    //NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-    //NSString *course_abbr = [saved stringForKey:@"currentCourseAbbr"];
     searchedPost[@"user_id"] = [FBSDKAccessToken currentAccessToken].userID;
     searchedPost[@"word_counts"] = dict;
     
@@ -141,10 +137,7 @@
     return score;
 }
 
-// Instead of sortBy in fetchPostsViewed
 - (void)sortByRecommendation {
-    //NSMutableDictionary *toSort = [[NSMutableDictionary alloc] init];
-    //NSInteger finalCount = [self.filteredPostArray count];
     for (PFObject* post in self.filteredPostArray) {
         NSString *allText = [NSString stringWithFormat:@"%@%@%@",
                              post[@"title"], @" ",
@@ -161,7 +154,6 @@
                 float scoreForPost = [self getWordMatchScore:viewedWordMappings firstCount:viewedCount secondDictionary:searchedWordMappings secondCount:searchedCount];
                 
                 [self.toSort setValue:post forKey:[NSString stringWithFormat:@"%f", scoreForPost]];
-
             } else {
                 NSLog(@"Error: %@", error.localizedDescription);
             }

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -39,7 +39,6 @@
     [self.searchBar addInteraction:interaction];
     
     [self setSortButtonMenu];
-    [self getCoursesWithCompletion];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -99,39 +98,6 @@
     [cell setSearchPostCell:self.filteredPostArray[indexPath.row]];
     
     return cell;
-}
-
-- (void)countWordsForSearchedPosts:(NSString *)postRead {
-    NSArray *words = [postRead componentsSeparatedByString:@" "];
-    for (NSString* word in words) {
-        if (![word isEqualToString:@""]) {
-            if ([self.wordCountDict objectForKey:word]) {
-                NSInteger count = (NSInteger)[self.wordCountDict valueForKey:word] + 1;
-                [self.wordCountDict setObject:[NSNumber numberWithInt:(int)count] forKey:word];
-            } else {
-                [self.wordCountDict setObject:@1 forKey:word];
-            }
-        }
-    }
-    [self createNewReadPost:self.wordCountDict];
-    NSLog(@"Word Count: %@", self.wordCountDict);
-}
-
-- (void)getCoursesWithCompletion {
-    PFQuery *query = [PFQuery queryWithClassName:@"SearchedPosts"];
-    query.limit = 20;
-
-    // fetch data asynchronously
-    [query findObjectsInBackgroundWithBlock:^(NSArray *result, NSError *error) {
-        if (result != nil) {
-            NSLog(@"Word counts: %@", result[0][@"word_counts"]);
-            NSLog(@"One word count: %@", result[0][@"word_counts"][@"this"]);
-            //completion(courses, nil);
-        } else {
-            //completion(nil, error);
-            NSLog(@"Error");
-        }
-    }];
 }
 
 - (void)createNewReadPost:(NSMutableDictionary *)dict {
@@ -211,7 +177,7 @@
     NSString *allText = [NSString stringWithFormat:@"%@%@%@",
                          self.filteredPostArray[indexPath.row][@"title"], @" ",
                          self.filteredPostArray[indexPath.row][@"message"]];
-    [self countWordsForSearchedPosts:allText];
+    [self.sharedManager updateSearchedWordProbabilities:allText];
     [self.sharedManager getPostDictFromIDWithCompletion:post_id completion:^(NSDictionary * _Nonnull post, NSError * _Nonnull error) {
         if (post) {
             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];


### PR DESCRIPTION
### Description
This PR builds on to #41, which implemented a button where the user can select a category to sort posts. This PR implements a sort method that depends on the posts that the user selected upon searching for them. 
This feature takes the ten most recently viewed posts, compares the probabilities of words showing up in the viewed posts and searched/selected posts, calculates scores for each viewed post based on the probabilities, and sorts them in descending score order.
This functionality still has some bugs. While I have successfully calculated and printed out the scores for each viewed post, my table cells are not showing up, likely due to issues with async calls. I will address this blocker in a future PR.

### Milestones
This feature fulfills the requirement “Sort posts in search view by order of how likely the user is to read each post”, which is part of technically ambiguous problem 2.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/183583081-ca89c972-ad89-4a6a-afb7-df7b49071cba.mov