### PR TITLE
Sort posts by text match

### DIFF
--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray *)getWordMappingFromText:(NSString *)text;
 
+- (NSDictionary *)getWordProbabilitiesFromText:(NSString *)text;
+
 - (void)createNewWordMappingForCurrentUser:(NSMutableDictionary *)dict incrementBy:(NSNumber *)count;
 
 - (void)updateSearchedWordFrequencies:(NSString *)text;

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -44,23 +44,6 @@
     }];
 }
 
-- (void)getProfilePicURLFromIDWithCompletion:(NSString *)user_id completion:(void(^)(NSString *profilePic, NSError *error))completion {
-    
-    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
-                                  initWithGraphPath:[NSString stringWithFormat:@"/%@/picture", user_id]
-                                  parameters:@{}
-                                  HTTPMethod:@"GET"];
-                                  
-    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
-        if (!error) {
-            NSString *pictureURL = result[@"data"][@"url"];
-            completion(pictureURL, nil);
-        } else {
-            completion(nil, error);
-        }
-    }];
-}
-
 - (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion {
     
     NSString *untilDateStr = until;

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -42,7 +42,24 @@
             completion(nil, error);
         }
     }];
-}     
+}
+
+- (void)getProfilePicURLFromIDWithCompletion:(NSString *)user_id completion:(void(^)(NSString *profilePic, NSError *error))completion {
+    
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+                                  initWithGraphPath:[NSString stringWithFormat:@"/%@/picture", user_id]
+                                  parameters:@{}
+                                  HTTPMethod:@"GET"];
+                                  
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        if (!error) {
+            NSString *pictureURL = result[@"data"][@"url"];
+            completion(pictureURL, nil);
+        } else {
+            completion(nil, error);
+        }
+    }];
+}
 
 - (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion {
     

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -124,11 +124,21 @@
     return @[wordCountDict, [NSNumber numberWithInteger:count]];
 }
 
+- (NSDictionary *)getWordProbabilitiesFromText:(NSString *)text {
+    NSArray *arr = [self getWordMappingFromText:text];
+    NSMutableDictionary *wordsMap = arr[0];
+    float count = [arr[1] floatValue];
+    NSMutableDictionary *toReturn = [[NSMutableDictionary alloc] init];
+    
+    for (NSString* word in wordsMap) {
+        float probability = [wordsMap[word] floatValue] / count;
+        [toReturn setObject:[NSNumber numberWithFloat:probability] forKey:word];
+    }
+    return toReturn;
+}
+
 - (void)createNewWordMappingForCurrentUser:(NSMutableDictionary *)dict incrementBy:(NSNumber *)count {
     PFObject *searchedPost = [[PFObject alloc] initWithClassName:@"SearchedPosts"];
-    
-    //NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-    //NSString *course_abbr = [saved stringForKey:@"currentCourseAbbr"];
     searchedPost[@"user_id"] = [FBSDKAccessToken currentAccessToken].userID;
     searchedPost[@"word_counts"] = dict;
     searchedPost[@"total_wordcount"] = count;

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -892,7 +892,6 @@
         <image name="house" catalog="system" width="128" height="106"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
         <image name="person.fill" catalog="system" width="128" height="120"/>
-        <image name="rectangle.and.pencil.and.ellipsis" catalog="system" width="128" height="81"/>
         <image name="shuffle" catalog="system" width="128" height="95"/>
         <image name="square.and.pencil" catalog="system" width="128" height="115"/>
         <systemColor name="labelColor">

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -86,6 +86,7 @@
     postInParse[@"course"] = self.postInfo.courses;
     postInParse[@"read_date"] = [NSDate date];
     postInParse[@"times_viewed"] = [NSNumber numberWithInt:1];
+    postInParse[@"word_probabilities"] = [self.sharedManager getWordProbabilitiesFromText:[NSString stringWithFormat:@"%@%@%@", self.postInfo.titleContent, @" ", self.postInfo.textContent]];
     
     NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
     NSString *course_abbr = [saved stringForKey:@"currentCourseAbbr"];

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -120,7 +120,7 @@
     float score = 0;
     for (NSString* word in searched) {
         if ([viewed objectForKey:word]) {   // found matching word in first dictionary
-            float pointVal = [viewed[word] floatValue] * ([searched[word] floatValue]/searchCount);  // P(word | dict1) * P(word | dict2)
+            float pointVal = [viewed[word] floatValue] * ([searched[word] floatValue]/searchCount);  // P(word | viewed dictionary) * P(word | searched dictionary)
             score += pointVal;
         }
     }

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -55,15 +55,6 @@
             self.postArray = [NSMutableArray arrayWithArray:result];
             self.filteredPostArray = self.postArray;
             [self sortByRecommendation];
-            
-            NSArray *dictKeys = [self.toSort allKeys];
-            NSArray *sortedKeys = [dictKeys sortedArrayUsingComparator:^NSComparisonResult(id dict1, id dict2) {
-                NSString *first = [self.toSort objectForKey:dict1];
-                NSString *second = [self.toSort objectForKey:dict2];
-                return [@([second floatValue]) compare:@([first floatValue])];
-            }];
-            self.filteredPostArray = [NSMutableArray arrayWithArray:sortedKeys];
-            [self.tableView reloadData];
         } else if (!error) {   // no courses viewed
             NSLog(@"No courses viewed yet!");
             UIAlertController *alert = [UIAlertController alertControllerWithTitle: @ "No posts viewed!"
@@ -125,40 +116,46 @@
     }];
 }
 
-- (float)getWordMatchScore:(NSDictionary *)dict1 firstCount:(float)count1 secondDictionary:(NSDictionary *)dict2 secondCount:(float)count2 {
+- (float)getWordMatchScore:(NSDictionary *)viewed searchDictionary:(NSDictionary *)searched searchCount:(float)searchCount {
     float score = 0;
-    for (NSString* word in dict2) {
-        if ([dict1 objectForKey:word]) {   // found matching word in first dictionary
-            float pointVal = ([dict1[word] floatValue]/count1) * ([dict2[word] floatValue]/count2);  // P(word | dict1) * P(word | dict2)
+    for (NSString* word in searched) {
+        if ([viewed objectForKey:word]) {   // found matching word in first dictionary
+            float pointVal = [viewed[word] floatValue] * ([searched[word] floatValue]/searchCount);  // P(word | dict1) * P(word | dict2)
             score += pointVal;
         }
     }
-    NSLog(@"Score = %f", score);
     return score;
 }
 
 - (void)sortByRecommendation {
-    for (PFObject* post in self.filteredPostArray) {
-        NSString *allText = [NSString stringWithFormat:@"%@%@%@",
-                             post[@"title"], @" ",
-                             post[@"message"]];
-        NSArray *viewedPostWords = [self.sharedManager getWordMappingFromText:allText];
-        NSDictionary *viewedWordMappings = viewedPostWords[0];
-        float viewedCount = [viewedPostWords[1] floatValue];
-        
-        [self.sharedManager getSearchDataWithCompletion:^(PFObject * _Nonnull data, NSError * _Nonnull error) {
-            if (!error) {
+    [self.sharedManager getSearchDataWithCompletion:^(PFObject * _Nonnull data, NSError * _Nonnull error) {
+        if (!error) {
+            NSMutableArray *postScorePairs = [[NSMutableArray alloc] init];
+            for (PFObject* post in self.filteredPostArray) {
+                NSDictionary *viewedProbs = post[@"word_probabilities"];
                 NSDictionary *searchedWordMappings = data[@"word_counts"];
                 float searchedCount = [data[@"total_wordcount"] floatValue];
+                float scoreForPost = [self getWordMatchScore:viewedProbs searchDictionary:searchedWordMappings searchCount:searchedCount];
                 
-                float scoreForPost = [self getWordMatchScore:viewedWordMappings firstCount:viewedCount secondDictionary:searchedWordMappings secondCount:searchedCount];
-                
-                [self.toSort setValue:post forKey:[NSString stringWithFormat:@"%f", scoreForPost]];
-            } else {
-                NSLog(@"Error: %@", error.localizedDescription);
+                NSArray *pair = @[post, [NSNumber numberWithFloat:scoreForPost]];
+                [postScorePairs addObject:pair];
             }
-        }];
-    }
+            
+            NSArray *sortedPosts = [postScorePairs sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+                return [obj2[1] compare:obj1[1]];
+            }];
+            
+            NSMutableArray *finalSortedPosts = [[NSMutableArray alloc] init];
+            for (id elem in sortedPosts) {
+                [finalSortedPosts addObject:elem[0]];
+            }
+            
+            self.filteredPostArray = [NSMutableArray arrayWithArray:finalSortedPosts];
+            [self.tableView reloadData];
+        } else {
+            NSLog(@"Error: %@", error.localizedDescription);
+        }
+    }];
 }
 
 
@@ -171,7 +168,10 @@
 
 - (void)setSortButtonMenu {
     [self.sortButton setShowsMenuAsPrimaryAction:YES];
-    UIAction *readDateSort = [UIAction actionWithTitle:@"Read date (default)" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
+    UIAction *customizedSort = [UIAction actionWithTitle:@"Recommended (default)" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
+        [self sortByRecommendation];
+    }];
+    UIAction *readDateSort = [UIAction actionWithTitle:@"Read date" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
         [self sortBy:@"read_date"];
     }];
     UIAction *postDateSort = [UIAction actionWithTitle:@"Post Date" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
@@ -180,10 +180,7 @@
     UIAction *timesViewedSort = [UIAction actionWithTitle:@"Times You Viewed" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
         [self sortBy:@"times_viewed"];
     }];
-    UIAction *customizedSort = [UIAction actionWithTitle:@"Customized" image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
-        // TODO: implement customized sorting algorithm
-    }];
-    self.sortButton.menu = [UIMenu menuWithTitle:@"Sort by: " children:@[readDateSort, postDateSort, timesViewedSort, customizedSort]];
+    self.sortButton.menu = [UIMenu menuWithTitle:@"Sort by: " children:@[customizedSort, readDateSort, postDateSort, timesViewedSort]];
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {


### PR DESCRIPTION
### Description
This PR builds on #43, which implemented a sorting system for viewed posts, where viewed posts with text that matched more often with searched/selected posts were given priority. First, I improved the efficiency of the word counting algorithm; whenever a post is viewed, I immediately calculate the probabilities of each word in the text showing up and store them in Parse to avoid recalculation. I also fixed some blockers that were preventing me from getting the posts to show up on the recommendations list. Now, when the user clicks the search tab bar button, they are led to a list of recommended posts, in order of text match, and can select different sorting algorithms by clicking the top right button.

### Milestones
This feature fulfills the requirement “Sort posts in search view by order of how likely the user is to read each post”, which is part of technically ambiguous problem 2.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/183830966-d7d82ab2-06ae-408c-82a8-612c16d89e9b.mov
