### PR TITLE
Feed loading fixes and API code moving

### DIFF
--- a/CapstoneProject.xcodeproj/project.pbxproj
+++ b/CapstoneProject.xcodeproj/project.pbxproj
@@ -203,13 +203,6 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		BE88045E28A07C5A00CAB4F3 /* Sorting Algorithms */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "Sorting Algorithms";
-            sourceTree = "<group>";
-        };
 		BE880457289F7A7400CAB4F3 /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -217,6 +210,13 @@
 				BE88045C289F7BD000CAB4F3 /* AppColors.m */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		BE88045E28A07C5A00CAB4F3 /* Sorting Algorithms */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "Sorting Algorithms";
 			sourceTree = "<group>";
 		};
 		BEA4666828781C0400D57C23 /* View Controllers */ = {

--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -7,6 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import "Parse/Parse.h"
+#import "Post.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getPostDictFromIDWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion;
 
+- (void)getPostObjectFromIDWithCompletion:(NSString *)post_id completion:(void (^)(Post *, NSError *))completion;
+
 - (void)getNextSetOfPostsWithCompletion:(NSString *)until startDate:(NSString *)since completion:(void(^)(NSMutableArray *posts, NSString *lastDate, NSError *error))completion;
 
 - (NSArray *)getWordMappingFromText:(NSString *)text;
@@ -41,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getSearchedWordFrequenciesWithCompletion:(void(^)(NSMutableDictionary *wordCounts, NSError *error))completion;
 
 - (void)getSearchDataWithCompletion:(void(^)(PFObject *data, NSError *error))completion;
+
+- (void)composeAnswerWithCompletion:(NSString *)text postToAnswer:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion;
 
 @end
 

--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)composeAnswerWithCompletion:(NSString *)text postToAnswer:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion;
 
+- (void)composeQuestionWithCompletion:(NSString *)title bodyText:(NSString *)body completion:(void(^)(NSDictionary *post, NSError *error))completion;
+
+- (void)getPostsViewedWithCompletion:(void(^)(NSArray *posts, NSError *error))completion;
+
+- (void)getCoursesWithCompletion:(void(^)(NSArray *courses, NSError *error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CapstoneProject/API Manager/APIManager.h
+++ b/CapstoneProject/API Manager/APIManager.h
@@ -14,9 +14,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (class, strong, readonly) APIManager *sharedManager;
 
-@property (nonatomic, copy, nullable) NSString *myString;
-
 @property (nonatomic, strong) NSCache *postCache;
+
+@property (nonatomic, strong) NSMutableArray *postsToBeCached;
+
+@property (nonatomic, strong) NSMutableArray *postArray;
+
+- (void)fetchPosts:(BOOL)isFirst;
+
+- (void)fetchPostsRec:(NSString *)course_id endDate:(nullable NSString *)until startDate:(nullable NSString *)since firstFetch:(BOOL)isFirst;
+
+- (void)fetchMorePosts;
 
 - (void)getPostDictFromIDWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion;
 

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -15,6 +15,8 @@
     self = [super init];
     if (self) {
         self.postCache = [[NSCache alloc] init];
+        self.postArray = [[NSMutableArray alloc] init];
+        self.postsToBeCached = [[NSMutableArray alloc] init];
     }
     return self;
 }
@@ -26,6 +28,81 @@
         sharedMyManager = [[self alloc] init];
     });
     return sharedMyManager;
+}
+
+- (void)fetchPosts:(BOOL)isFirst {
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    NSString *course_id = [saved stringForKey:@"currentCourse"];
+    NSLog(@"course_id = %@", course_id);
+    
+    if (isFirst) {
+        [self.postArray removeAllObjects];
+        [self.postsToBeCached removeAllObjects];
+    }
+    
+    [self fetchPostsRec:course_id endDate:nil startDate:nil firstFetch:isFirst];
+}
+
+- (void)fetchPostsRec:(NSString *)course_id endDate:(NSString *)until startDate:(NSString *)since firstFetch:(BOOL)isFirst {
+    __block NSInteger numPosts = 0;
+    [self getNextSetOfPostsWithCompletion:until startDate:since completion:^(NSMutableArray *posts, NSString *lastDate, NSError *error) {
+        if (!error) {
+            if ([posts count] == 0) {   // no more posts left in Facebook Group: load posts to tableView
+                if (isFirst) {
+                    [self.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                }
+                // Notify question feed
+                [[NSNotificationCenter defaultCenter]
+                        postNotificationName:@"DidFetchNotification"
+                        object:self];
+                return;
+            }
+            
+            for (Post *post in posts) {   // filter posts by current course
+                [self.postsToBeCached addObject:post];
+                if ([post.parent_post_id isEqualToString:@""] && [post.courses isEqualToString:course_id]) {
+                    [self.postArray addObject:post];
+                    numPosts++;
+                }
+            }
+
+            if (numPosts < 5) {   // not enough posts displayed
+                NSLog(@"count = %lu", (unsigned long)[self.postArray count]);
+                NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+                [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
+                NSLog(@"Date = %@", [dateFormat stringFromDate:((Post *)[self.postArray lastObject]).post_date]);
+                [self fetchPostsRec:course_id endDate:lastDate startDate:nil firstFetch:isFirst];
+            } else {   // enough posts: load posts to tableView
+                __weak typeof(self) weakSelf = self;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    __strong typeof(self) strongSelf = weakSelf;
+                    if (strongSelf) {
+                        if (isFirst) {
+                            [self.postCache setObject:self.postsToBeCached forKey:@"posts"];
+                        }
+                        // Notify question feed
+                        [[NSNotificationCenter defaultCenter]
+                                postNotificationName:@"DidFetchNotification"
+                                object:self];
+                        return;
+                    }
+                });
+            }
+        } else {
+            NSLog(@"Error: %@", error.localizedDescription);
+            // TODO: get posts from cache instead
+        }
+    }];
+}
+
+- (void)fetchMorePosts {
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    NSString *course_id = [saved stringForKey:@"currentCourse"];
+    
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    [dateFormat setDateFormat:@"yyyy-MM-ddTHH:mm:ssZ"];
+    NSString *dateStr = [dateFormat stringFromDate:((Post *)[self.postArray lastObject]).post_date];
+    [self fetchPostsRec:course_id endDate:dateStr startDate:nil firstFetch:NO];
 }
 
 - (void)getPostDictFromIDWithCompletion:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion {
@@ -54,7 +131,7 @@
     }
     
     if (sinceDateStr == nil) {   // set 'since' to two weeks before until
-        double daysinInterval = 3;  // number of days into the past to get posts up to
+        double daysinInterval = 7;  // number of days into the past to get posts up to
         NSTimeInterval twoWeekInterval = (NSTimeInterval)(daysinInterval * -86400);
         
         NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];

--- a/CapstoneProject/API Manager/APIManager.m
+++ b/CapstoneProject/API Manager/APIManager.m
@@ -7,7 +7,6 @@
 
 #import "APIManager.h"
 #import "FBSDKCoreKit/FBSDKCoreKit.h"
-#import "Post.h"
 
 @implementation APIManager
 
@@ -116,6 +115,24 @@
         if (!error) {
             completion(result, nil);
         } else {
+            completion(nil, error);
+        }
+    }];
+}
+
+- (void)getPostObjectFromIDWithCompletion:(NSString *)post_id completion:(void (^)(Post *, NSError *))completion {
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+                                  initWithGraphPath:[NSString stringWithFormat:@"/%@", post_id]
+                                  parameters:@{ @"fields": @"from, created_time, message"}
+                                  HTTPMethod:@"GET"];
+    
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        if (!error) {
+            NSLog(@"%@", result);
+            Post *post = [[Post alloc] initWithDictionary:result];
+            completion(post, nil);
+        } else {
+            NSLog(@"Error posting to feed: %@", error.localizedDescription);
             completion(nil, error);
         }
     }];
@@ -287,6 +304,24 @@
             completion(nil, nil);
         } else {
             NSLog(@"Error: %@", error.localizedDescription);
+            completion(nil, error);
+        }
+    }];
+}
+
+- (void)composeAnswerWithCompletion:(NSString *)text postToAnswer:(NSString *)post_id completion:(void(^)(NSDictionary *post, NSError *error))completion {
+    NSString *messageWithDelimiters = [NSString stringWithFormat:@"%@%@%@", text, @"/0\n\n", post_id];
+    FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
+                                  initWithGraphPath:@"/425184976239857/feed"
+                                  parameters:@{ @"message": messageWithDelimiters}
+                                  HTTPMethod:@"POST"];
+    
+    [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+        if (!error) {
+            NSLog(@"Success!");
+            completion(result, nil);
+        } else {
+            NSLog(@"Error posting to feed: %@", error.localizedDescription);
             completion(nil, error);
         }
     }];

--- a/CapstoneProject/View Controllers/AnsweringViewController.h
+++ b/CapstoneProject/View Controllers/AnsweringViewController.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import "Post.h"
+#import "APIManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UILabel *descriptionLabel;
 @property (weak, nonatomic) IBOutlet UITextView *answerText;
 @property (strong, nonatomic) Post *postToAnswerInfo;
+@property (nonatomic, strong) APIManager *sharedManager;
 
 @end
 

--- a/CapstoneProject/View Controllers/ComposeViewController.h
+++ b/CapstoneProject/View Controllers/ComposeViewController.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import "Post.h"
+#import "APIManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ComposeViewController : UIViewController
 
 @property (nonatomic, weak) id<ComposeViewControllerDelegate> delegate;
+
+@property (nonatomic, strong) APIManager *sharedManager;
 
 @end
 

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.h
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.h
@@ -18,9 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableArray *postArray;
 
-@property (nonatomic, strong) APIManager *sharedManager;
-
 @property (nonatomic, strong) NSMutableArray *postsToBeCached;
+
+@property (nonatomic, strong) APIManager *sharedManager;
 
 @property (assign, nonatomic) BOOL isMoreDataLoading;
 

--- a/CapstoneProject/View Controllers/QuestionFeedViewController.m
+++ b/CapstoneProject/View Controllers/QuestionFeedViewController.m
@@ -41,10 +41,6 @@
     self.sharedManager = [APIManager sharedManager];
     self.isMoreDataLoading = NO;
     
-    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
-    NSString *course_id = [saved stringForKey:@"currentCourseAbbr"];
-    self.navigationItem.title = [NSString stringWithFormat:@"%@ Home", course_id];
-    
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didFetchPosts:)
                                                  name:@"DidFetchNotification"
@@ -58,10 +54,6 @@
 
 - (void) didFetchPosts:(NSNotification *) notification
 {
-    // [notification name] should always be @"TestNotification"
-    // unless you use this method for observation of other notifications
-    // as well.
-
     if ([[notification name] isEqualToString:@"DidFetchNotification"]) {
         self.postArray = self.sharedManager.postArray;
         self.isMoreDataLoading = NO;
@@ -125,8 +117,11 @@
     self.loading.ringThickness = 3;
     [self.view addSubview:self.loading];
     [self.loading startAnimating];
-    
     [self.sharedManager fetchPosts:YES];
+    
+    NSUserDefaults *saved = [NSUserDefaults standardUserDefaults];
+    NSString *course_id = [saved stringForKey:@"currentCourseAbbr"];
+    self.navigationItem.title = [NSString stringWithFormat:@"%@ Home", course_id];
 }
 
 

--- a/CapstoneProject/View Controllers/SearchPostsViewController.m
+++ b/CapstoneProject/View Controllers/SearchPostsViewController.m
@@ -50,7 +50,7 @@
 }
 
 - (void)fetchPostsViewed {
-    [self getPostsViewedWithCompletion:^(NSArray *result, NSError *error) {
+    [self.sharedManager getPostsViewedWithCompletion:^(NSArray *result, NSError *error) {
         if ([result count] != 0) {
             self.postArray = [NSMutableArray arrayWithArray:result];
             self.filteredPostArray = self.postArray;
@@ -65,25 +65,6 @@
             [self presentViewController: alert animated: true completion: nil];
         } else {
             NSLog(@"Error: %@", error.localizedDescription);
-        }
-    }];
-}
-
-- (void)getPostsViewedWithCompletion:(void(^)(NSArray *posts, NSError *error))completion {
-    NSString *current_user_id = [FBSDKAccessToken currentAccessToken].userID;
-    NSString *userInParse = [NSString stringWithFormat:@"%@%@", @"user", current_user_id];
-    
-    PFQuery *query = [PFQuery queryWithClassName:userInParse];
-    [query orderByDescending:@"read_date"];
-    query.limit = 10;
-
-    [query findObjectsInBackgroundWithBlock:^(NSArray *posts, NSError *error) {
-        if (posts != nil) {
-            NSLog(@"Posts viewed: %@", posts);
-            completion(posts, nil);
-        } else {
-            NSLog(@"%@", error.localizedDescription);
-            completion(nil, error);
         }
     }];
 }

--- a/CapstoneProject/View Controllers/SelectCourseViewController.h
+++ b/CapstoneProject/View Controllers/SelectCourseViewController.h
@@ -7,12 +7,15 @@
 
 #import <UIKit/UIKit.h>
 #import "Parse/Parse.h"
+#import "APIManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SelectCourseViewController : UIViewController
 
 @property (nonatomic, strong) NSMutableArray *courseArray;
+
+@property (nonatomic, strong) APIManager *sharedManager;
 
 @end
 

--- a/CapstoneProject/View Controllers/SelectCourseViewController.m
+++ b/CapstoneProject/View Controllers/SelectCourseViewController.m
@@ -20,6 +20,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.sharedManager = [APIManager sharedManager];
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
@@ -28,28 +29,12 @@
 }
 
 - (void)fetchCourses {
-    [self getCoursesWithCompletion:^(NSArray *courses, NSError *error) {
+    [self.sharedManager getCoursesWithCompletion:^(NSArray *courses, NSError *error) {
         if (error) {
             NSLog(@"Error: %@", error.localizedDescription);
         } else {
             self.courseArray = [NSMutableArray arrayWithArray:courses];
             [self.tableView reloadData];
-        }
-    }];
-}
-
-
-- (void)getCoursesWithCompletion:(void(^)(NSArray *courses, NSError *error))completion {
-    PFQuery *query = [PFQuery queryWithClassName:@"Course"];
-    query.limit = 20;
-
-    // fetch data asynchronously
-    [query findObjectsInBackgroundWithBlock:^(NSArray *result, NSError *error) {
-        if (result != nil) {
-            NSMutableArray *courses = [NSMutableArray arrayWithArray:result];
-            completion(courses, nil);
-        } else {
-            completion(nil, error);
         }
     }];
 }

--- a/CapstoneProject/Views/PostCell.m
+++ b/CapstoneProject/Views/PostCell.m
@@ -30,9 +30,9 @@
     self.nameLabel.textColor = [UIColor ht_wetAsphaltColor];
     self.postText.text = post.textContent;
     self.dateLabel.text = post.post_createdAt;
-    self.dateLabel.textColor = [UIColor ht_lavenderDarkColor];
+    self.dateLabel.textColor = [UIColor ht_asbestosColor];
     self.timestampLabel.text = post.post_date.shortTimeAgoSinceNow;
-    self.timestampLabel.textColor = [UIColor ht_lavenderDarkColor];
+    self.timestampLabel.textColor = [UIColor ht_asbestosColor];
     [self setRandomColor];
 }
 


### PR DESCRIPTION
### Description
This PR moves all methods that fetch data from the Facebook API or Parse to the shared APIManager class in order to keep the functionality of the code in the view controller classes limited to displaying views. 
While this change may not be apparent at first glance, the feed looks much cleaner while loading posts, and does not glitch in between. Also, when switching courses or reloading the feed, the feed that was present before still shows up behind the progress HUD before switching to the updated feed. Finally, I also fixed a small bug when displaying the navigation title of the feed — now, the feed view controller always displays the correct course name as the title.

### Milestones
This PR does not add to a specific feature, but improves the functionality of several features (such as the "Display the user feed" MVP feature) through cleaner coding techniques.

### Test Plan

https://user-images.githubusercontent.com/107252243/184076193-5f022102-3f43-437c-9a16-d79a33eb1607.mov