### PR TITLE
Auto layout fix

### DIFF
--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -611,49 +611,44 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="CourseCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CourseCell" id="BPH-Fr-szb" customClass="CourseCell">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="119.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="CourseCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CourseCell" rowHeight="151" id="BPH-Fr-szb" customClass="CourseCell">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="151"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BPH-Fr-szb" id="KXv-qF-Mau">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="119.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="151"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="An Intro to Making: What is EE" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M3p-02-uZi">
-                                                    <rect key="frame" x="126" y="69.5" width="280" height="29"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="29" id="Tbv-ZA-c3n"/>
-                                                    </constraints>
+                                                    <rect key="frame" x="153" y="63" width="241" height="69"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="YUc-5q-S3F">
-                                                    <rect key="frame" x="0.0" y="-0.5" width="113" height="120.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="136" height="151"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="113" id="7fB-Q9-jVx"/>
+                                                        <constraint firstAttribute="width" constant="136" id="5LV-nK-8Bn"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENGR 40M" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CaM-On-eIz">
-                                                    <rect key="frame" x="126" y="19" width="280" height="40.5"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="40" id="zx7-qb-vlU"/>
-                                                    </constraints>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ENGR 40M" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CaM-On-eIz">
+                                                    <rect key="frame" x="153" y="20" width="241" height="30"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="YUc-5q-S3F" firstAttribute="height" secondItem="KXv-qF-Mau" secondAttribute="height" multiplier="0.912134" constant="11" id="CT1-qK-D5d"/>
-                                                <constraint firstItem="CaM-On-eIz" firstAttribute="leading" secondItem="YUc-5q-S3F" secondAttribute="trailing" constant="13" id="GfF-71-8sj"/>
-                                                <constraint firstItem="M3p-02-uZi" firstAttribute="leading" secondItem="CaM-On-eIz" secondAttribute="leading" id="O8x-aR-HUh"/>
-                                                <constraint firstItem="YUc-5q-S3F" firstAttribute="leading" secondItem="KXv-qF-Mau" secondAttribute="leading" id="QWN-B1-qo6"/>
-                                                <constraint firstAttribute="bottom" secondItem="M3p-02-uZi" secondAttribute="bottom" constant="21" id="bka-FI-YeR"/>
-                                                <constraint firstAttribute="trailing" secondItem="CaM-On-eIz" secondAttribute="trailing" constant="8" id="c3o-w5-xX4"/>
-                                                <constraint firstItem="CaM-On-eIz" firstAttribute="top" secondItem="KXv-qF-Mau" secondAttribute="top" constant="19" id="jPS-XO-XO8"/>
-                                                <constraint firstItem="YUc-5q-S3F" firstAttribute="centerY" secondItem="KXv-qF-Mau" secondAttribute="centerY" id="jd2-XZ-kx7"/>
-                                                <constraint firstItem="M3p-02-uZi" firstAttribute="top" secondItem="CaM-On-eIz" secondAttribute="bottom" constant="10" id="rvO-3p-22h"/>
-                                                <constraint firstItem="M3p-02-uZi" firstAttribute="trailing" secondItem="CaM-On-eIz" secondAttribute="trailing" id="xHz-Sq-11S"/>
+                                                <constraint firstItem="YUc-5q-S3F" firstAttribute="top" secondItem="CaM-On-eIz" secondAttribute="bottom" constant="-50" id="0Vd-Ge-7xT"/>
+                                                <constraint firstItem="YUc-5q-S3F" firstAttribute="height" secondItem="KXv-qF-Mau" secondAttribute="height" id="3Br-LM-QHQ"/>
+                                                <constraint firstAttribute="bottom" secondItem="M3p-02-uZi" secondAttribute="bottom" constant="19" id="DAI-P2-ggi"/>
+                                                <constraint firstItem="M3p-02-uZi" firstAttribute="leading" secondItem="CaM-On-eIz" secondAttribute="leading" id="Egd-Ge-wdy"/>
+                                                <constraint firstItem="M3p-02-uZi" firstAttribute="top" secondItem="CaM-On-eIz" secondAttribute="bottom" constant="13" id="HO7-wO-dr7"/>
+                                                <constraint firstItem="M3p-02-uZi" firstAttribute="trailing" secondItem="CaM-On-eIz" secondAttribute="trailing" id="JyL-fG-RqO"/>
+                                                <constraint firstItem="CaM-On-eIz" firstAttribute="leading" secondItem="YUc-5q-S3F" secondAttribute="trailing" constant="17" id="dKh-oC-VEJ"/>
+                                                <constraint firstItem="M3p-02-uZi" firstAttribute="top" secondItem="YUc-5q-S3F" secondAttribute="bottom" constant="-88" id="tfv-Go-Wrx"/>
+                                                <constraint firstAttribute="trailing" secondItem="CaM-On-eIz" secondAttribute="trailing" constant="20" symbolic="YES" id="vX5-zZ-AmK"/>
+                                                <constraint firstItem="CaM-On-eIz" firstAttribute="top" secondItem="KXv-qF-Mau" secondAttribute="top" constant="20" id="x9a-G6-eoO"/>
+                                                <constraint firstItem="YUc-5q-S3F" firstAttribute="leading" secondItem="KXv-qF-Mau" secondAttribute="leading" id="yYB-Ez-KQD"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>

--- a/CapstoneProject/Base.lproj/Main.storyboard
+++ b/CapstoneProject/Base.lproj/Main.storyboard
@@ -204,16 +204,16 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Question Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ZA-sR-0Ay">
-                                <rect key="frame" x="20" y="88" width="374" height="30"/>
+                                <rect key="frame" x="20" y="102" width="374" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8SL-sU-K9W">
-                                <rect key="frame" x="0.0" y="201.5" width="414" height="171"/>
+                                <rect key="frame" x="0.0" y="215.5" width="414" height="171"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Question Description" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C7U-GX-NSk">
-                                        <rect key="frame" x="13" y="15" width="160" height="20.5"/>
+                                        <rect key="frame" x="13" y="15" width="388" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -222,29 +222,23 @@
                                 <color key="backgroundColor" red="0.92986940412630514" green="0.95838975362031642" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstItem="C7U-GX-NSk" firstAttribute="leading" secondItem="8SL-sU-K9W" secondAttribute="leading" constant="13" id="7sf-c9-TW5"/>
-                                    <constraint firstAttribute="bottom" secondItem="C7U-GX-NSk" secondAttribute="bottom" constant="118" id="CBo-wF-sxe"/>
+                                    <constraint firstAttribute="bottom" secondItem="C7U-GX-NSk" secondAttribute="bottom" constant="135" id="CBo-wF-sxe"/>
                                     <constraint firstAttribute="trailing" secondItem="C7U-GX-NSk" secondAttribute="trailing" constant="13" id="HwW-Mw-Et1"/>
+                                    <constraint firstItem="C7U-GX-NSk" firstAttribute="centerX" secondItem="8SL-sU-K9W" secondAttribute="centerX" id="aTp-PD-bT7"/>
                                     <constraint firstItem="C7U-GX-NSk" firstAttribute="top" secondItem="8SL-sU-K9W" secondAttribute="top" constant="15" id="bSH-oc-lqN"/>
                                     <constraint firstAttribute="height" constant="171" id="wWe-x8-hgu"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="sMq-aX-oOA"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="Xsd-aG-91Z"/>
                             </scrollView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BEg-Qw-3QV">
-                                <rect key="frame" x="20" y="138.5" width="48" height="45.5"/>
-                                <color key="tintColor" red="0.47478711530000001" green="0.48709458709999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="48" id="Zmp-Ng-b0K"/>
-                                </constraints>
-                            </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="87f-VR-vJw">
-                                <rect key="frame" x="85" y="166" width="309" height="18"/>
+                                <rect key="frame" x="85" y="180" width="309" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="cLz-zM-xIt">
-                                <rect key="frame" x="0.0" y="481" width="414" height="415"/>
+                                <rect key="frame" x="0.0" y="495" width="414" height="401"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="sectionIndexBackgroundColor" red="0.87929017549999999" green="0.92362233910000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <prototypes>
@@ -296,26 +290,26 @@
                                 </prototypes>
                             </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2Q-ad-h1I">
-                                <rect key="frame" x="20" y="433" width="107" height="27"/>
+                                <rect key="frame" x="20" y="447" width="107" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VwJ-Dz-ude">
-                                <rect key="frame" x="20" y="471.5" width="374" height="1"/>
+                                <rect key="frame" x="20" y="485.5" width="374" height="1"/>
                                 <color key="backgroundColor" systemColor="systemGray3Color"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="nBb-IE-NhV"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Anonymous" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y5W-ns-RF6">
-                                <rect key="frame" x="85" y="137" width="309" height="22"/>
+                                <rect key="frame" x="85" y="151" width="309" height="22"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33p-eE-T9X" customClass="HTPressableButton">
-                                <rect key="frame" x="271" y="380" width="102.5" height="31"/>
+                                <rect key="frame" x="271" y="394" width="102.5" height="31"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="UR0-Pg-wpM"/>
                                 </constraints>
@@ -325,13 +319,20 @@
                                     <segue destination="z7o-os-hQ5" kind="presentation" identifier="answerSegue" id="Q7C-pp-3Tv"/>
                                 </connections>
                             </button>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="BEg-Qw-3QV">
+                                <rect key="frame" x="20" y="152.5" width="48" height="44.5"/>
+                                <color key="tintColor" red="0.47478711530000001" green="0.48709458709999998" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="48" id="Zmp-Ng-b0K"/>
+                                </constraints>
+                            </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="bRU-Qa-uYY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstItem="8SL-sU-K9W" firstAttribute="top" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="16" id="0Pb-UJ-1cz"/>
-                            <constraint firstItem="6ZA-sR-0Ay" firstAttribute="top" secondItem="bRU-Qa-uYY" secondAttribute="top" id="0X7-yf-Yow"/>
+                            <constraint firstItem="8SL-sU-K9W" firstAttribute="top" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="17" id="0Pb-UJ-1cz"/>
+                            <constraint firstItem="6ZA-sR-0Ay" firstAttribute="top" secondItem="bRU-Qa-uYY" secondAttribute="top" constant="14" id="0X7-yf-Yow"/>
                             <constraint firstItem="y5W-ns-RF6" firstAttribute="leading" secondItem="BEg-Qw-3QV" secondAttribute="trailing" constant="17" id="2Ao-jL-u9l"/>
                             <constraint firstItem="87f-VR-vJw" firstAttribute="top" secondItem="y5W-ns-RF6" secondAttribute="bottom" constant="7" id="32F-sj-ptz"/>
                             <constraint firstItem="6ZA-sR-0Ay" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" constant="20" id="4JS-Ng-OAN"/>
@@ -344,7 +345,7 @@
                             <constraint firstItem="8SL-sU-K9W" firstAttribute="leading" secondItem="bRU-Qa-uYY" secondAttribute="leading" id="Seb-R5-C9U"/>
                             <constraint firstItem="y5W-ns-RF6" firstAttribute="trailing" secondItem="6ZA-sR-0Ay" secondAttribute="trailing" id="WP1-lq-zqB"/>
                             <constraint firstItem="BEg-Qw-3QV" firstAttribute="top" secondItem="6ZA-sR-0Ay" secondAttribute="bottom" constant="19" id="Y2f-QV-iuI"/>
-                            <constraint firstItem="87f-VR-vJw" firstAttribute="bottom" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="-1.5" id="ZH0-IB-WsZ"/>
+                            <constraint firstItem="87f-VR-vJw" firstAttribute="bottom" secondItem="BEg-Qw-3QV" secondAttribute="bottom" constant="-0.5" id="ZH0-IB-WsZ"/>
                             <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="I2Q-ad-h1I" secondAttribute="trailing" constant="287" id="Zdf-uS-FAL"/>
                             <constraint firstItem="33p-eE-T9X" firstAttribute="top" secondItem="8SL-sU-K9W" secondAttribute="bottom" constant="7.5" id="a4z-v8-0Nv"/>
                             <constraint firstItem="bRU-Qa-uYY" firstAttribute="trailing" secondItem="cLz-zM-xIt" secondAttribute="trailing" id="a9G-yL-AQs"/>
@@ -370,6 +371,7 @@
                         <outlet property="answerButton" destination="33p-eE-T9X" id="8ep-uo-39h"/>
                         <outlet property="dateLabel" destination="87f-VR-vJw" id="Ic2-of-52j"/>
                         <outlet property="descriptionLabel" destination="C7U-GX-NSk" id="gF8-52-Ub3"/>
+                        <outlet property="descriptionScrollView" destination="8SL-sU-K9W" id="uFg-wW-lmu"/>
                         <outlet property="nameLabel" destination="y5W-ns-RF6" id="Qqg-sC-HpF"/>
                         <outlet property="profileImage" destination="BEg-Qw-3QV" id="JY1-rU-1Rn"/>
                         <outlet property="tableView" destination="cLz-zM-xIt" id="m6x-id-UJH"/>
@@ -516,7 +518,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Write something..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QoT-ae-fh7">
-                                <rect key="frame" x="25" y="135.5" width="134.5" height="33"/>
+                                <rect key="frame" x="25" y="136" width="185" height="33"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
@@ -528,7 +530,7 @@
                             <constraint firstItem="QoT-ae-fh7" firstAttribute="leading" secondItem="Z0y-oD-QlO" secondAttribute="leading" constant="5" id="0ba-Qy-cMR"/>
                             <constraint firstItem="QoT-ae-fh7" firstAttribute="top" secondItem="Z0y-oD-QlO" secondAttribute="top" id="3Ba-qi-HfO"/>
                             <constraint firstItem="1Zc-eU-7Mw" firstAttribute="bottom" secondItem="Z0y-oD-QlO" secondAttribute="bottom" constant="322" id="IwV-pP-ipJ"/>
-                            <constraint firstItem="QoT-ae-fh7" firstAttribute="width" secondItem="Z0y-oD-QlO" secondAttribute="height" multiplier="122:349" id="J0t-sO-YsW"/>
+                            <constraint firstItem="QoT-ae-fh7" firstAttribute="width" secondItem="Z0y-oD-QlO" secondAttribute="height" multiplier="122:349" constant="50.59025787965615" id="J0t-sO-YsW"/>
                             <constraint firstItem="HoA-7G-mBI" firstAttribute="width" secondItem="axT-Pa-5g3" secondAttribute="height" multiplier="113:61" constant="-18.926229508196727" id="NTZ-E7-uh5"/>
                             <constraint firstItem="HoA-7G-mBI" firstAttribute="leading" secondItem="axT-Pa-5g3" secondAttribute="leading" constant="5" id="O9j-JT-oIP"/>
                             <constraint firstItem="Z0y-oD-QlO" firstAttribute="trailing" secondItem="axT-Pa-5g3" secondAttribute="trailing" id="Oxf-Zh-ofd"/>

--- a/CapstoneProject/View Controllers/AnsweringViewController.m
+++ b/CapstoneProject/View Controllers/AnsweringViewController.m
@@ -30,7 +30,9 @@
     
     self.answerText.delegate = self;
     self.answerText.layer.borderWidth = 1.0;
-    self.answerText.layer.borderColor = [[UIColor blackColor] CGColor];
+    self.answerText.layer.borderColor = [[UIColor ht_leadColor] CGColor];
+    self.answerText.layer.cornerRadius = 5;
+    self.answerText.clipsToBounds = YES;
   
     self.answerButton.translatesAutoresizingMaskIntoConstraints = YES;
     self.answerButton = [[HTPressableButton alloc] initWithFrame:CGRectMake(self.view.frame.size.width/2 - 175, 500, 350, 40) buttonStyle:HTPressableButtonStyleRounded];

--- a/CapstoneProject/View Controllers/ComposeViewController.m
+++ b/CapstoneProject/View Controllers/ComposeViewController.m
@@ -26,9 +26,13 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.titleText.layer.borderWidth = 1.0;
-    self.titleText.layer.borderColor = [[UIColor blackColor] CGColor];
+    self.titleText.layer.borderColor = [[UIColor ht_leadColor] CGColor];
     self.postText.layer.borderWidth = 1.0;
-    self.postText.layer.borderColor = [[UIColor blackColor] CGColor];
+    self.postText.layer.borderColor = [[UIColor ht_leadColor] CGColor];
+    self.titleText.layer.cornerRadius = 5;
+    self.titleText.clipsToBounds = YES;
+    self.postText.layer.cornerRadius = 5;
+    self.postText.clipsToBounds = YES;
     self.titleText.delegate = self;
     self.postText.delegate = self;
 

--- a/CapstoneProject/View Controllers/PostDetailsViewController.h
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) Post *postInfo;
 @property (nonatomic, strong) APIManager *sharedManager;
 @property (nonatomic, strong) NSMutableArray *commentArray;
+@property (weak, nonatomic) IBOutlet UIScrollView *descriptionScrollView;
 
 @end
 

--- a/CapstoneProject/View Controllers/PostDetailsViewController.m
+++ b/CapstoneProject/View Controllers/PostDetailsViewController.m
@@ -36,6 +36,8 @@
     self.nameLabel.text = self.postInfo.user_name;
     self.dateLabel.text = self.postInfo.post_date_detailed;
     self.descriptionLabel.text = self.postInfo.textContent;
+    self.descriptionScrollView.contentSize = CGSizeMake(self.tableView.contentSize.width, 500);
+
     
     self.answerButton.translatesAutoresizingMaskIntoConstraints = YES;
     self.answerButton = [[HTPressableButton alloc] initWithFrame:self.answerButton.frame buttonStyle:HTPressableButtonStyleRounded];


### PR DESCRIPTION
### Description
This PR adds auto layout fixes to the following view controllers:
- Post details view controller: The scroll view for the text now scrolls vertically, and the title is not squashed at the top anymore.
- Course selection view controller: All of the text in the course cells show.
- Compose answer view controller: The placeholder text shows fully.
In addition, I rounded and lightened the color of the rectangular borders on my text views for composing a post and commenting to match the atmosphere of the rest of the app.

### Milestones
This feature does not fulfill any requirements, but polishes the UI of my app.

### Test Plan
Here is a screen recording for this PR:

https://user-images.githubusercontent.com/107252243/184100349-32b11854-0ff6-4130-be7c-cf0f596b7e6d.mov
